### PR TITLE
control acks

### DIFF
--- a/connect/transfer_contract_manager.go
+++ b/connect/transfer_contract_manager.go
@@ -125,6 +125,8 @@ type ContractManager struct {
 	contractErrorCallbacks *CallbackList[ContractErrorFunction]
 
 	localStats *ContractManagerStats
+
+	controlSyncProvide *ControlSync
 }
 
 func NewContractManagerWithDefaults(ctx context.Context, client *Client) *ContractManager {
@@ -160,6 +162,7 @@ func NewContractManager(
 		sendNoContractClientIds:    sendNoContractClientIds,
 		contractErrorCallbacks:     NewCallbackList[ContractErrorFunction](),
 		localStats:                 NewContractManagerStats(),
+		controlSyncProvide:         NewControlSync(ctx, client, "provide"),
 	}
 
 	return contractManager
@@ -288,8 +291,9 @@ func (self *ContractManager) SetProvidePaused(providePaused bool) {
 		provide := &protocol.Provide{
 			Keys: []*protocol.ProvideKey{},
 		}
-		self.client.SendControl(
+		self.controlSyncProvide.Send(
 			RequireToFrame(provide),
+			nil,
 			nil,
 		)
 	} else {
@@ -304,8 +308,9 @@ func (self *ContractManager) SetProvidePaused(providePaused bool) {
 		provide := &protocol.Provide{
 			Keys: provideKeys,
 		}
-		self.client.SendControl(
+		self.controlSyncProvide.Send(
 			RequireToFrame(provide),
+			nil,
 			nil,
 		)
 	}
@@ -370,8 +375,9 @@ func (self *ContractManager) SetProvideModesWithAckCallback(provideModes map[pro
 		provide := &protocol.Provide{
 			Keys: provideKeys,
 		}
-		self.client.SendControl(
+		self.controlSyncProvide.Send(
 			RequireToFrame(provide),
+			nil,
 			ackCallback,
 		)
 	}

--- a/connect/transfer_control.go
+++ b/connect/transfer_control.go
@@ -1,0 +1,175 @@
+package connect
+
+import (
+	"context"
+	"sync"
+
+	"github.com/golang/glog"
+
+	"bringyour.com/protocol"
+)
+
+// control sync is a pattern to sync control messages between the server and client
+// it ensures:
+// - control messages are sent in order
+// - only the latest message per scope is retried.
+//   Create one `ControlSync` object per scope.
+// - if a send fails due to ack timeout or other local error, the send is retried
+
+type ControlSync struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	client   *Client
+	scopeTag string
+
+	monitor *Monitor
+
+	sendLock  sync.Mutex
+	syncCount uint64
+}
+
+func NewControlSync(ctx context.Context, client *Client, scopeTag string) *ControlSync {
+	cancelCtx, cancel := context.WithCancel(ctx)
+
+	return &ControlSync{
+		ctx:       cancelCtx,
+		cancel:    cancel,
+		client:    client,
+		scopeTag:  scopeTag,
+		monitor:   NewMonitor(),
+		syncCount: 0,
+	}
+}
+
+func (self *ControlSync) Send(frame *protocol.Frame, updateFrame func() *protocol.Frame, ackCallback AckFunction) {
+	// 1. try to send non-blocking
+	// 2. if fails, send blocking with no timeout
+	// 3. keep retying on error until the handle context or client is closed
+
+	safeAckCallback := func(err error) {
+		if ackCallback != nil {
+			HandleError(func() {
+				ackCallback(err)
+			})
+		}
+	}
+
+	handleCtx, handleCancel := context.WithCancel(self.ctx)
+	notify := self.monitor.NotifyAll()
+	go func() {
+		defer handleCancel()
+
+		select {
+		case <-notify:
+		case <-handleCtx.Done():
+		}
+	}()
+
+	self.sendLock.Lock()
+	defer self.sendLock.Unlock()
+
+	self.syncCount += 1
+	syncIndex := self.syncCount
+
+	select {
+	case <-notify:
+		return
+	case <-handleCtx.Done():
+		return
+	default:
+	}
+
+	var controlSync func()
+	controlSync = func() {
+		defer handleCancel()
+
+		defer func() {
+			self.sendLock.Lock()
+			defer self.sendLock.Unlock()
+			if self.syncCount == syncIndex {
+				glog.Infof("[control][%d]stop sync for scope = %s\n", syncIndex, self.scopeTag)
+			} else {
+				glog.Infof("[control][%d]replace sync for scope = %s\n", syncIndex, self.scopeTag)
+			}
+		}()
+
+		updatedFrame := frame
+
+		for {
+			glog.Infof("[control][%d]start sync for scope = %s\n", syncIndex, self.scopeTag)
+
+			done := false
+			success := false
+			var err error
+			func() {
+				self.sendLock.Lock()
+				defer self.sendLock.Unlock()
+
+				select {
+				case <-notify:
+					done = true
+					return
+				case <-handleCtx.Done():
+					done = true
+					return
+				default:
+				}
+
+				success, err = self.client.SendWithTimeoutDetailed(
+					updatedFrame,
+					DestinationId(ControlId),
+					func(err error) {
+						if err == nil {
+							safeAckCallback(err)
+						} else {
+							go controlSync()
+						}
+					},
+					-1,
+					Ctx(handleCtx),
+				)
+			}()
+			if done || success {
+				return
+			}
+			if err != nil {
+				// only stop when the context or client is done
+				select {
+				case <-handleCtx.Done():
+					return
+				case <-self.client.Done():
+					return
+				default:
+				}
+			}
+			// else try again
+			if updateFrame != nil {
+				updatedFrame = updateFrame()
+			}
+		}
+	}
+
+	success, _ := self.client.SendWithTimeoutDetailed(
+		frame,
+		DestinationId(ControlId),
+		func(err error) {
+			if err == nil {
+				safeAckCallback(err)
+			} else {
+				go controlSync()
+			}
+		},
+		0,
+		Ctx(handleCtx),
+	)
+	if success {
+		return
+	}
+
+	go controlSync()
+}
+
+func (self *ControlSync) Close() {
+	self.cancel()
+}

--- a/connect/transfer_control_test.go
+++ b/connect/transfer_control_test.go
@@ -1,0 +1,141 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+	mathrand "math/rand"
+	"testing"
+	"time"
+
+	"github.com/go-playground/assert/v2"
+
+	"bringyour.com/protocol"
+)
+
+func TestControlSync(t *testing.T) {
+	// control sync to flood control messages,
+	// drop transports for longer than ack timeout
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	timeout := 60 * time.Second
+	dropTimeout := 5 * time.Second
+	allowTimeout := 500 * time.Millisecond
+	ackTimeout := 100 * time.Millisecond
+	sendDelay := 20 * time.Millisecond
+
+	k := 4
+	b := 1000
+
+	clientASettings := DefaultClientSettings()
+	clientASettings.SendBufferSettings.AckTimeout = ackTimeout
+	clientA := NewClient(ctx, NewId(), NewNoContractClientOob(), clientASettings)
+
+	controlClientA := NewClientWithDefaults(ctx, ControlId, NewNoContractClientOob())
+	controlClientA.ContractManager().AddNoContractPeer(clientA.ClientId())
+
+	controlSyncM1 := NewControlSync(ctx, clientA, "m1")
+
+	receive := make(chan *protocol.SimpleMessage)
+
+	// on receive a test message, set the channel
+	controlClientA.AddReceiveCallback(func(source TransferPath, frames []*protocol.Frame, provideMode protocol.ProvideMode) {
+		for _, frame := range frames {
+			m, err := FromFrame(frame)
+			assert.Equal(t, err, nil)
+			switch v := m.(type) {
+			case *protocol.SimpleMessage:
+				select {
+				case <-ctx.Done():
+				case receive <- v:
+				case <-time.After(timeout):
+					t.FailNow()
+				}
+			}
+		}
+	})
+
+	for i := range k {
+		go func() {
+			for j := range b {
+				frame, err := ToFrame(&protocol.SimpleMessage{
+					MessageIndex: uint32(i*b + j),
+				})
+				assert.Equal(t, err, nil)
+				controlSyncM1.Send(
+					frame,
+					nil,
+					nil,
+				)
+				select {
+				case <-time.After(time.Duration(mathrand.Intn(int(sendDelay)))):
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+
+		go func() {
+			for {
+				// wait
+				// create transport
+				// wait
+				// drop transport
+
+				select {
+				case <-ctx.Done():
+				case <-time.After(dropTimeout):
+				}
+
+				clientASendTransport := NewSendGatewayTransport()
+				clientAReceiveTransport := NewReceiveGatewayTransport()
+
+				controlClientASendTransport := NewSendGatewayTransport()
+				controlClientAReceiveTransport := NewReceiveGatewayTransport()
+
+				clientASend := make(chan []byte)
+				clientAReceive := make(chan []byte)
+
+				clientA.RouteManager().UpdateTransport(clientASendTransport, []Route{clientASend})
+				clientA.RouteManager().UpdateTransport(clientAReceiveTransport, []Route{clientAReceive})
+
+				controlClientA.RouteManager().UpdateTransport(controlClientASendTransport, []Route{clientAReceive})
+				controlClientA.RouteManager().UpdateTransport(controlClientAReceiveTransport, []Route{clientASend})
+
+				select {
+				case <-ctx.Done():
+				case <-time.After(allowTimeout):
+				}
+
+				clientA.RouteManager().UpdateTransport(clientASendTransport, nil)
+				clientA.RouteManager().UpdateTransport(clientAReceiveTransport, nil)
+
+				controlClientA.RouteManager().UpdateTransport(controlClientASendTransport, nil)
+				controlClientA.RouteManager().UpdateTransport(controlClientAReceiveTransport, nil)
+			}
+		}()
+
+		func() {
+			p := uint32(0)
+			for {
+				// select from message channel
+				// when select message k + b, stop
+				// if timeout, error
+
+				select {
+				case m := <-receive:
+					assert.Equal(t, p <= m.MessageIndex, true)
+					p = m.MessageIndex
+					end := uint32(b*i + b - 1)
+					fmt.Printf("[cs0]%d/%d\n", m.MessageIndex, end)
+					if m.MessageIndex == end {
+						return
+					}
+				case <-time.After(timeout):
+					t.FailNow()
+				}
+			}
+		}()
+	}
+}

--- a/connect/util.go
+++ b/connect/util.go
@@ -33,11 +33,12 @@ func (self *Monitor) NotifyChannel() chan struct{} {
 	return self.notify
 }
 
-func (self *Monitor) NotifyAll() {
+func (self *Monitor) NotifyAll() chan struct{} {
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
 	close(self.notify)
 	self.notify = make(chan struct{})
+	return self.notify
 }
 
 // makes a copy of the list on update


### PR DESCRIPTION
Use a control sync pattern for control messages.

Revert previous changes where control messages did not time out. This would cause hanging buffer issues, which would be confusing to debug.