### PR TITLE
provide ping

### DIFF
--- a/connect/connect.go
+++ b/connect/connect.go
@@ -220,6 +220,18 @@ func (self Id) Bytes() []byte {
 	return self[0:16]
 }
 
+func (self Id) LessThan(b Id) bool {
+	for i, v := range self {
+		if v < b[i] {
+			return true
+		}
+		if b[i] < v {
+			return false
+		}
+	}
+	return false
+}
+
 func (self Id) String() string {
 	return encodeUuid(self)
 }

--- a/connect/connect_test.go
+++ b/connect/connect_test.go
@@ -19,6 +19,22 @@ func initGlog() {
 	flag.Set("v", "0")
 }
 
+func TestIdOrder(t *testing.T) {
+	// ulids are ordered by create time
+	// we use this property in the system, where ulids from the same source can be ordered
+
+	a := NewId()
+	for range 1024 * 1024 {
+		b := NewId()
+		assert.Equal(t, a.LessThan(b), true)
+		assert.Equal(t, b.LessThan(a), false)
+		assert.Equal(t, b.LessThan(b), false)
+		assert.Equal(t, b == a, false)
+		assert.Equal(t, b == b, true)
+		a = b
+	}
+}
+
 func TestIdJsonCodec(t *testing.T) {
 	type Test struct {
 		A Id  `json:"a,omitempty"`

--- a/connect/frame.go
+++ b/connect/frame.go
@@ -41,6 +41,10 @@ func ToFrame(message proto.Message) (*protocol.Frame, error) {
 		messageType = protocol.MessageType_IpIpPacketFromProvider
 	case *protocol.IpPing:
 		messageType = protocol.MessageType_IpIpPing
+	case *protocol.ControlPing:
+		messageType = protocol.MessageType_TransferControlPing
+	case *protocol.ProvidePing:
+		messageType = protocol.MessageType_TransferProvidePing
 	default:
 		return nil, fmt.Errorf("Unknown message type: %T", v)
 	}
@@ -95,6 +99,10 @@ func FromFrame(frame *protocol.Frame) (proto.Message, error) {
 		message = &protocol.IpPacketFromProvider{}
 	case protocol.MessageType_IpIpPing:
 		message = &protocol.IpPing{}
+	case protocol.MessageType_TransferControlPing:
+		message = &protocol.ControlPing{}
+	case protocol.MessageType_TransferProvidePing:
+		message = &protocol.ProvidePing{}
 	default:
 		return nil, fmt.Errorf("Unknown message type: %s", frame.MessageType)
 	}

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -1150,6 +1150,7 @@ func NewTcpSequence(ctx context.Context, receiveCallback ReceivePacketFunction,
 	tcpBufferSettings *TcpBufferSettings) *TcpSequence {
 	cancelCtx, cancel := context.WithCancel(ctx)
 
+	// FIXME scaled window size
 	var windowSize uint16
 	if math.MaxUint16 < tcpBufferSettings.WindowSize {
 		windowSize = math.MaxUint16

--- a/connect/transfer_control_test.go
+++ b/connect/transfer_control_test.go
@@ -125,10 +125,11 @@ func TestControlSync(t *testing.T) {
 
 				select {
 				case m := <-receive:
+					end := uint32(b*i + b - 1)
+					fmt.Printf("[csync]%d/%d (%d)\n", m.MessageIndex, end, p)
+
 					assert.Equal(t, p <= m.MessageIndex, true)
 					p = m.MessageIndex
-					end := uint32(b*i + b - 1)
-					fmt.Printf("[cs0]%d/%d\n", m.MessageIndex, end)
 					if m.MessageIndex == end {
 						return
 					}

--- a/connect/transfer_test.go
+++ b/connect/transfer_test.go
@@ -204,6 +204,13 @@ func TestSendReceiveSenderReset(t *testing.T) {
 		aClientId,
 	)
 
+	select {
+	case message := <-receives:
+		// an older message was delivered
+		assert.Equal(t, message, nil)
+	default:
+	}
+
 	go func() {
 		for i := 0; i < n; i += 1 {
 			message := &protocol.SimpleMessage{

--- a/connect/transport.go
+++ b/connect/transport.go
@@ -39,7 +39,7 @@ type PlatformTransportSettings struct {
 }
 
 func DefaultPlatformTransportSettings() *PlatformTransportSettings {
-	pingTimeout := 15 * time.Second
+	pingTimeout := 1 * time.Second
 	return &PlatformTransportSettings{
 		HttpConnectTimeout: 2 * time.Second,
 		WsHandshakeTimeout: 2 * time.Second,
@@ -47,7 +47,7 @@ func DefaultPlatformTransportSettings() *PlatformTransportSettings {
 		ReconnectTimeout:   5 * time.Second,
 		PingTimeout:        pingTimeout,
 		WriteTimeout:       5 * time.Second,
-		ReadTimeout:        4 * pingTimeout,
+		ReadTimeout:        15 * time.Second,
 	}
 }
 

--- a/connect/transport.go
+++ b/connect/transport.go
@@ -39,7 +39,7 @@ type PlatformTransportSettings struct {
 }
 
 func DefaultPlatformTransportSettings() *PlatformTransportSettings {
-	pingTimeout := 5 * time.Second
+	pingTimeout := 15 * time.Second
 	return &PlatformTransportSettings{
 		HttpConnectTimeout: 2 * time.Second,
 		WsHandshakeTimeout: 2 * time.Second,
@@ -47,7 +47,7 @@ func DefaultPlatformTransportSettings() *PlatformTransportSettings {
 		ReconnectTimeout:   5 * time.Second,
 		PingTimeout:        pingTimeout,
 		WriteTimeout:       5 * time.Second,
-		ReadTimeout:        2 * pingTimeout,
+		ReadTimeout:        4 * pingTimeout,
 	}
 }
 

--- a/protocol/frame.proto
+++ b/protocol/frame.proto
@@ -25,6 +25,8 @@ enum MessageType {
     IpIpPacketToProvider = 15;
     IpIpPacketFromProvider = 16;
     IpIpPing = 17;
+    TransferControlPing = 18;
+    TransferProvidePing = 19;
 }
 
 

--- a/protocol/transfer.proto
+++ b/protocol/transfer.proto
@@ -107,6 +107,7 @@ enum ProvideMode {
     FriendsAndFamily = 2;
     Public = 3;
     Stream = 4;
+    PublicStream = 5;
 }
 
 
@@ -244,5 +245,13 @@ message PeerAudit {
     uint64 resend_count = 12;
     // ulid
     bytes stream_id = 13;
+}
+
+
+message ControlPing {
+}
+
+
+message ProvidePing {
 }
 


### PR DESCRIPTION
1. Decouple the provide ping from the transport ping. Generally we want to allow a longer transport timeout and a shorter provide ping. This means providers will test end to end response from control faster, and re-establish failed state faster.

2. Contract manager retains previously used provide keys until application restart. This reduces contract churn and makes it faster for clients to reconnect after provide on-off-on sequences.

3. Address a correctness issue in `transport` with multiple sequence ids. When a sender reforms a sequence faster than the receiver timeout, the receiver could have received messages in parallel from multiple sequences. This breaks the ordered guarantee per source. Now we deliver messages from the most recent sequence only.
