### PR TITLE
transfer perf

### DIFF
--- a/api/bringyour.yml
+++ b/api/bringyour.yml
@@ -1078,8 +1078,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/SetPayoutWalletResult"
-
-    /account/payout-wallet:
         get:
             description: |
                 Fetches the payout wallet associated with the network

--- a/connect/connect.go
+++ b/connect/connect.go
@@ -384,9 +384,9 @@ func kib(c ByteCount) ByteCount {
 }
 
 func mib(c ByteCount) ByteCount {
-	return c * ByteCount(1024*1024)
+	return c * ByteCount(1024) * ByteCount(1024)
 }
 
 func gib(c ByteCount) ByteCount {
-	return c * ByteCount(1024*1024*1024)
+	return c * ByteCount(1024) * ByteCount(1024) * ByteCount(1024)
 }

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -80,8 +80,9 @@ func DefaultTcpBufferSettings() *TcpBufferSettings {
 		// avoid fragmentation
 		ReadBufferByteCount: DefaultMtu - max(Ipv4HeaderSizeWithoutExtensions, Ipv6HeaderSize) - max(UdpHeaderSize, TcpHeaderSizeWithoutExtensions),
 		WindowSize:          uint32(mib(1)),
-		WindowScale:         uint32(4),
-		UserLimit:           128,
+		// TODO can this be auto computed?
+		WindowScale: uint32(4),
+		UserLimit:   128,
 	}
 	return tcpBufferSettings
 }

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -922,6 +922,7 @@ type TcpBufferSettings struct {
 	Mtu                 int
 	// the window size is the max amount of packet data in memory for each sequence
 	// `WindowSize / 2^WindowScale` must fit in uint16
+	// see https://datatracker.ietf.org/doc/html/rfc1323#page-8
 	WindowScale uint32
 	WindowSize  uint32
 	// the number of open sockets per user
@@ -1667,7 +1668,8 @@ func (self *ConnectionState) SynAck() ([]byte, error) {
 		windowScaleOpt := layers.TCPOption{
 			OptionType:   layers.TCPOptionKindWindowScale,
 			OptionLength: 3,
-			OptionData:   windowScaleBytes[1:4],
+			// one byte
+			OptionData: windowScaleBytes[3:4],
 		}
 		opts = append(opts, windowScaleOpt)
 	}
@@ -1680,8 +1682,6 @@ func (self *ConnectionState) SynAck() ([]byte, error) {
 		ACK:     true,
 		SYN:     true,
 		Window:  self.encodedWindowSize,
-		// TODO window scale
-		// https://datatracker.ietf.org/doc/html/rfc1323#page-8
 		Options: opts,
 	}
 	tcp.SetNetworkLayerForChecksum(ip)

--- a/connect/ip.go
+++ b/connect/ip.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -78,7 +79,8 @@ func DefaultTcpBufferSettings() *TcpBufferSettings {
 		Mtu:                DefaultMtu,
 		// avoid fragmentation
 		ReadBufferByteCount: DefaultMtu - max(Ipv4HeaderSizeWithoutExtensions, Ipv6HeaderSize) - max(UdpHeaderSize, TcpHeaderSizeWithoutExtensions),
-		WindowSize:          int(mib(1)),
+		WindowSize:          uint32(mib(1)),
+		WindowScale:         uint32(4),
 		UserLimit:           128,
 	}
 	return tcpBufferSettings
@@ -919,9 +921,9 @@ type TcpBufferSettings struct {
 	SequenceBufferSize  int
 	Mtu                 int
 	// the window size is the max amount of packet data in memory for each sequence
-	// TODO currently we do not enable window scale
-	// TODO this value is max 2^16
-	WindowSize int
+	// `WindowSize / 2^WindowScale` must fit in uint16
+	WindowScale uint32
+	WindowSize  uint32
 	// the number of open sockets per user
 	// uses an lru cleanup where new sockets over the limit close old sockets
 	UserLimit int
@@ -956,14 +958,6 @@ func (self *Tcp4Buffer) send(source TransferPath, provideMode protocol.ProvideMo
 		tcp,
 		timeout,
 	)
-}
-
-func (self *TcpSequence) Cancel() {
-	self.cancel()
-}
-
-func (self *TcpSequence) Close() {
-	self.cancel()
 }
 
 type Tcp6Buffer struct {
@@ -1150,14 +1144,6 @@ func NewTcpSequence(ctx context.Context, receiveCallback ReceivePacketFunction,
 	tcpBufferSettings *TcpBufferSettings) *TcpSequence {
 	cancelCtx, cancel := context.WithCancel(ctx)
 
-	// FIXME scaled window size
-	var windowSize uint16
-	if math.MaxUint16 < tcpBufferSettings.WindowSize {
-		windowSize = math.MaxUint16
-	} else {
-		windowSize = uint16(tcpBufferSettings.WindowSize)
-	}
-
 	connectionState := ConnectionState{
 		source:          source,
 		ipVersion:       ipVersion,
@@ -1166,8 +1152,10 @@ func NewTcpSequence(ctx context.Context, receiveCallback ReceivePacketFunction,
 		destinationIp:   destinationIp,
 		destinationPort: destinationPort,
 		// the window size starts at the fixed value
-		windowSize:  windowSize,
-		userLimited: *newUserLimited(),
+		enableWindowScale: false,
+		windowSize:        tcpBufferSettings.WindowSize,
+		windowScale:       tcpBufferSettings.WindowScale,
+		userLimited:       *newUserLimited(),
 	}
 	return &TcpSequence{
 		ctx:               cancelCtx,
@@ -1271,7 +1259,36 @@ func (self *TcpSequence) Run() {
 					// this is arbitrary, and since there is no transport security risk back to sender is fine
 					self.receiveSeq = sendItem.tcp.Seq
 					self.receiveSeqAck = sendItem.tcp.Seq
-					self.receiveWindowSize = sendItem.tcp.Window
+
+					parseWindowScaleOpts := func() (bool, uint32) {
+						for _, opt := range sendItem.tcp.Options {
+							if opt.OptionType == layers.TCPOptionKindWindowScale {
+								// fmt.Printf("[init]OPTION DATA = %v (%d,%d)\n", opt.OptionData, len(opt.OptionData), opt.OptionLength)
+								windowScaleBytes := make([]byte, 4)
+								copy(windowScaleBytes[4-len(opt.OptionData):4], opt.OptionData)
+								windowScale := min(
+									binary.BigEndian.Uint32(windowScaleBytes[0:4]),
+									// see 2.3  Using the Window Scale Option
+									14,
+								)
+								return true, windowScale
+							}
+						}
+						return false, 0
+					}
+
+					self.enableWindowScale, self.receiveWindowScale = parseWindowScaleOpts()
+					self.receiveWindowSize = uint32(sendItem.tcp.Window) << self.receiveWindowScale
+					if !self.enableWindowScale {
+						// turn off window scale for send
+						self.windowScale = 0
+					}
+					glog.V(2).Infof("[init]window=%d/%d, receive=%d/%d\n", self.windowSize, self.windowScale, self.receiveWindowSize, self.receiveWindowScale)
+					self.encodedWindowSize = uint16(min(
+						uint32(self.windowSize>>self.windowScale),
+						uint32(math.MaxUint16),
+					))
+
 					packet, err = self.SynAck()
 					self.receiveSeq += 1
 				}()
@@ -1418,59 +1435,23 @@ func (self *TcpSequence) Run() {
 		}
 	}()
 
+	type writePayload struct {
+		sendIter uint64
+		payload  []byte
+	}
+
+	writePayloads := make(chan writePayload, self.tcpBufferSettings.SequenceBufferSize)
 	go func() {
 		defer self.cancel()
 
-		for sendIter := 0; ; sendIter += 1 {
-			checkpointId := self.idleCondition.Checkpoint()
+		for {
 			select {
 			case <-self.ctx.Done():
 				return
-			case sendItem := <-self.sendItems:
-				if glog.V(2) {
-					if "ACK" != tcpFlagsString(sendItem.tcp) {
-						glog.Infof("[r%d]receive(%d %s)\n", sendIter, len(sendItem.tcp.Payload), tcpFlagsString(sendItem.tcp))
-					}
-				}
-
-				drop := false
-				seq := 0
-
-				func() {
-					self.mutex.Lock()
-					defer self.mutex.Unlock()
-
-					if self.sendSeq != sendItem.tcp.Seq {
-						// a retransmit
-						// since the transfer from local to remote is lossless and preserves order,
-						// the packet is already pending. Ignore.
-						drop = true
-					} else if sendItem.tcp.ACK {
-						// acks are reliably delivered (see above)
-						// we do not need to resend receive packets on missing acks
-						// note the window size can be be adjusted at any time for the same receive seq number,
-						// e.g. ->0 then ->full on receiver full
-						if self.receiveSeqAck <= sendItem.tcp.Ack {
-							self.receiveWindowSize = sendItem.tcp.Window
-							self.receiveSeqAck = sendItem.tcp.Ack
-							receiveAckCond.Broadcast()
-						}
-					}
-				}()
-
-				if drop {
-					continue
-				}
-
-				if sendItem.tcp.FIN {
-					glog.V(2).Infof("[r%d]FIN\n", sendIter)
-					seq += 1
-				}
-
+			case writePayload := <-writePayloads:
+				payload := writePayload.payload
+				sendIter := writePayload.sendIter
 				writeEndTime := time.Now().Add(self.tcpBufferSettings.WriteTimeout)
-
-				payload := sendItem.tcp.Payload
-				seq += len(payload)
 				for i := 0; i < len(payload); {
 					select {
 					case <-self.ctx.Done():
@@ -1504,47 +1485,111 @@ func (self *TcpSequence) Run() {
 						}
 					}
 				}
-
-				if 0 < seq {
-					var packet []byte
-					var err error
-					func() {
-						self.mutex.Lock()
-						defer self.mutex.Unlock()
-
-						self.sendSeq += uint32(seq)
-						packet, err = self.PureAck()
-					}()
-					if err == nil {
-						receive(packet)
-					}
-				}
-
-				if sendItem.tcp.FIN {
-					// close the socket to propage the FIN and close the sequence
-					socket.Close()
-				}
-
-				if sendItem.tcp.RST {
-					// a RST typically appears for a bad TCP segment
-					glog.V(2).Infof("[r%d]RST\n", sendIter)
-					return
-				}
-
-			case <-time.After(self.tcpBufferSettings.IdleTimeout):
-				if self.idleCondition.Close(checkpointId) {
-					// close the sequence
-					glog.V(2).Infof("[r%d]timeout\n", sendIter)
-					return
-				}
-				// else there pending updates
 			}
 		}
 	}()
 
-	select {
-	case <-self.ctx.Done():
+	for sendIter := uint64(0); ; sendIter += 1 {
+		checkpointId := self.idleCondition.Checkpoint()
+		select {
+		case <-self.ctx.Done():
+			return
+		case sendItem := <-self.sendItems:
+			if glog.V(2) {
+				if "ACK" != tcpFlagsString(sendItem.tcp) {
+					glog.Infof("[r%d]receive(%d %s)\n", sendIter, len(sendItem.tcp.Payload), tcpFlagsString(sendItem.tcp))
+				}
+			}
+
+			drop := false
+			seq := 0
+
+			func() {
+				self.mutex.Lock()
+				defer self.mutex.Unlock()
+
+				if self.sendSeq != sendItem.tcp.Seq {
+					// a retransmit
+					// since the transfer from local to remote is lossless and preserves order,
+					// the packet is already pending. Ignore.
+					drop = true
+				} else if sendItem.tcp.ACK {
+					// acks are reliably delivered (see above)
+					// we do not need to resend receive packets on missing acks
+					// note the window size can be be adjusted at any time for the same receive seq number,
+					// e.g. ->0 then ->full on receiver full
+					if self.receiveSeqAck <= sendItem.tcp.Ack {
+						self.receiveWindowSize = uint32(sendItem.tcp.Window) << self.receiveWindowScale
+						self.receiveSeqAck = sendItem.tcp.Ack
+						receiveAckCond.Broadcast()
+					}
+				}
+			}()
+
+			if drop {
+				continue
+			}
+
+			if sendItem.tcp.FIN {
+				glog.V(2).Infof("[r%d]FIN\n", sendIter)
+				seq += 1
+			}
+
+			payload := sendItem.tcp.Payload
+			seq += len(payload)
+
+			select {
+			case <-self.ctx.Done():
+				return
+			case writePayloads <- writePayload{
+				payload:  payload,
+				sendIter: sendIter,
+			}:
+			}
+
+			if 0 < seq {
+				var packet []byte
+				var err error
+				func() {
+					self.mutex.Lock()
+					defer self.mutex.Unlock()
+
+					self.sendSeq += uint32(seq)
+					packet, err = self.PureAck()
+				}()
+				if err == nil {
+					receive(packet)
+				}
+			}
+
+			if sendItem.tcp.FIN {
+				// close the socket to propage the FIN and close the sequence
+				socket.Close()
+			}
+
+			if sendItem.tcp.RST {
+				// a RST typically appears for a bad TCP segment
+				glog.V(2).Infof("[r%d]RST\n", sendIter)
+				return
+			}
+
+		case <-time.After(self.tcpBufferSettings.IdleTimeout):
+			if self.idleCondition.Close(checkpointId) {
+				// close the sequence
+				glog.V(2).Infof("[r%d]timeout\n", sendIter)
+				return
+			}
+			// else there pending updates
+		}
 	}
+}
+
+func (self *TcpSequence) Cancel() {
+	self.cancel()
+}
+
+func (self *TcpSequence) Close() {
+	self.cancel()
 }
 
 type TcpSendItem struct {
@@ -1562,11 +1607,15 @@ type ConnectionState struct {
 
 	mutex sync.Mutex
 
-	sendSeq           uint32
-	receiveSeq        uint32
-	receiveSeqAck     uint32
-	receiveWindowSize uint16
-	windowSize        uint16
+	sendSeq            uint32
+	receiveSeq         uint32
+	receiveSeqAck      uint32
+	receiveWindowSize  uint32
+	receiveWindowScale uint32
+	enableWindowScale  bool
+	windowSize         uint32
+	windowScale        uint32
+	encodedWindowSize  uint16
 
 	userLimited
 }
@@ -1609,6 +1658,20 @@ func (self *ConnectionState) SynAck() ([]byte, error) {
 		headerSize += Ipv6HeaderSize
 	}
 
+	opts := []layers.TCPOption{}
+
+	if self.enableWindowScale {
+		windowScaleBytes := make([]byte, 4)
+		binary.BigEndian.PutUint32(windowScaleBytes[0:4], self.windowScale)
+
+		windowScaleOpt := layers.TCPOption{
+			OptionType:   layers.TCPOptionKindWindowScale,
+			OptionLength: 3,
+			OptionData:   windowScaleBytes[1:4],
+		}
+		opts = append(opts, windowScaleOpt)
+	}
+
 	tcp := layers.TCP{
 		SrcPort: self.destinationPort,
 		DstPort: self.sourcePort,
@@ -1616,9 +1679,10 @@ func (self *ConnectionState) SynAck() ([]byte, error) {
 		Ack:     self.sendSeq,
 		ACK:     true,
 		SYN:     true,
-		Window:  self.windowSize,
+		Window:  self.encodedWindowSize,
 		// TODO window scale
 		// https://datatracker.ietf.org/doc/html/rfc1323#page-8
+		Options: opts,
 	}
 	tcp.SetNetworkLayerForChecksum(ip)
 	headerSize += TcpHeaderSizeWithoutExtensions
@@ -1672,7 +1736,7 @@ func (self *ConnectionState) PureAck() ([]byte, error) {
 		Seq:     self.receiveSeq,
 		Ack:     self.sendSeq,
 		ACK:     true,
-		Window:  self.windowSize,
+		Window:  self.encodedWindowSize,
 	}
 	tcp.SetNetworkLayerForChecksum(ip)
 	headerSize += TcpHeaderSizeWithoutExtensions
@@ -1727,7 +1791,7 @@ func (self *ConnectionState) FinAck() ([]byte, error) {
 		Ack:     self.sendSeq,
 		ACK:     true,
 		FIN:     true,
-		Window:  self.windowSize,
+		Window:  self.encodedWindowSize,
 	}
 	tcp.SetNetworkLayerForChecksum(ip)
 	headerSize += TcpHeaderSizeWithoutExtensions
@@ -1782,7 +1846,7 @@ func (self *ConnectionState) RstAck() ([]byte, error) {
 		Ack:     self.sendSeq,
 		ACK:     true,
 		RST:     true,
-		Window:  self.windowSize,
+		Window:  self.encodedWindowSize,
 	}
 	tcp.SetNetworkLayerForChecksum(ip)
 	headerSize += TcpHeaderSizeWithoutExtensions
@@ -1836,7 +1900,7 @@ func (self *ConnectionState) DataPackets(payload []byte, n int, mtu int) ([][]by
 		Seq:     self.receiveSeq,
 		Ack:     self.sendSeq,
 		ACK:     true,
-		Window:  self.windowSize,
+		Window:  self.encodedWindowSize,
 	}
 	tcp.SetNetworkLayerForChecksum(ip)
 	headerSize += TcpHeaderSizeWithoutExtensions

--- a/connect/ip_remote_multi_client.go
+++ b/connect/ip_remote_multi_client.go
@@ -1605,6 +1605,8 @@ func (self *multiClientChannel) detectBlackhole() {
 			select {
 			case <-self.ctx.Done():
 				return
+			case <-self.client.Done():
+				return
 			case <-time.After(timeout):
 			}
 		}
@@ -1887,6 +1889,8 @@ func (self *multiClientChannel) windowStatsWithCoalesce(coalesce bool) (*clientW
 	if err == nil {
 		select {
 		case <-self.ctx.Done():
+			err = errors.New("Done.")
+		case <-self.client.Done():
 			err = errors.New("Done.")
 		default:
 		}

--- a/connect/ip_remote_multi_client_test.go
+++ b/connect/ip_remote_multi_client_test.go
@@ -197,6 +197,9 @@ func TestMultiClientChannelWindowStats(t *testing.T) {
 		removeClientArgs: func(args *MultiClientGeneratorClientArgs) {
 			// do nothing
 		},
+		removeClientWithArgs: func(client *Client, args *MultiClientGeneratorClientArgs) {
+			// do nothing
+		},
 		newClientSettings: DefaultClientSettings,
 		newClient: func(ctx context.Context, args *MultiClientGeneratorClientArgs, clientSettings *ClientSettings) (*Client, error) {
 			client := NewClient(ctx, args.ClientId, NewNoContractClientOob(), clientSettings)

--- a/connect/net_http.go
+++ b/connect/net_http.go
@@ -542,7 +542,7 @@ func (self *ClientStrategy) HttpSerial(request *http.Request, helloRequest *http
 	// 3. continue from 1 until timeout
 
 	eval := func(handleCtx context.Context, dialer *clientDialer) *evalResult {
-		glog.Infof("[net]http serial %s %s\n", request.Method, request.URL)
+		glog.V(2).Infof("[net]http serial %s %s\n", request.Method, request.URL)
 
 		httpClient := dialer.HttpClient(self.settings)
 		response, err := httpClient.Do(request.WithContext(handleCtx))
@@ -552,7 +552,7 @@ func (self *ClientStrategy) HttpSerial(request *http.Request, helloRequest *http
 		return newEvalResultFromHttpResponse(response, err)
 	}
 	helloEval := func(handleCtx context.Context, dialer *clientDialer) *evalResult {
-		glog.Infof("[net]http serial hello %s %s\n", request.Method, request.URL)
+		glog.V(2).Infof("[net]http serial hello %s %s\n", request.Method, request.URL)
 
 		httpClient := dialer.HttpClient(self.settings)
 		response, err := httpClient.Do(helloRequest.WithContext(handleCtx))
@@ -571,7 +571,7 @@ func (self *ClientStrategy) HttpSerial(request *http.Request, helloRequest *http
 
 func (self *ClientStrategy) WsDialContext(ctx context.Context, url string, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
 	eval := func(handleCtx context.Context, dialer *clientDialer) *evalResult {
-		glog.Infof("[net]ws dial %s\n", url)
+		glog.V(2).Infof("[net]ws dial %s\n", url)
 
 		wsDialer := dialer.WsDialer(self.settings)
 		wsConn, response, err := wsDialer.DialContext(handleCtx, url, requestHeader)

--- a/connect/trace.go
+++ b/connect/trace.go
@@ -41,6 +41,7 @@ func IsDoneError(r any) bool {
 func HandleError(do func(), handlers ...any) (r any) {
 	defer func() {
 		if r = recover(); r != nil {
+			fmt.Printf("HANDLE ERROR: %s\n", r)
 			if IsDoneError(r) {
 				// the context was canceled and raised. this is a standard pattern, do not log
 			} else {

--- a/connect/trace.go
+++ b/connect/trace.go
@@ -92,6 +92,17 @@ func TraceWithReturn[R any](tag string, do func() R) (result R) {
 	return
 }
 
+func TraceWithReturnError[R any](tag string, do func() (R, error)) (result R, returnErr error) {
+	trace(tag, func() string {
+		result, returnErr = do()
+		if returnErr != nil {
+			return fmt.Sprintf(" err = %s", returnErr)
+		}
+		return fmt.Sprintf(" = %v", result)
+	})
+	return
+}
+
 func trace(tag string, do func() string) {
 	start := time.Now()
 	glog.Infof("[%-8s]%s (%d)\n", "start", tag, start.UnixMilli())

--- a/connect/transfer.go
+++ b/connect/transfer.go
@@ -89,12 +89,12 @@ func DefaultSendBufferSettings() *SendBufferSettings {
 		MinResendInterval:           1 * time.Second,
 		MaxResendInterval:           5 * time.Second,
 		// no backoff
-		ResendBackoffScale: 0,
-		RttScale:           1.5,
-		RttWindowSize:      128,
-		RttWindowTimeout:   5 * time.Second,
-		AckTimeout:         60 * time.Second,
-		IdleTimeout:        60 * time.Second,
+		// ResendBackoffScale: 0,
+		RttScale:         1.2,
+		RttWindowSize:    128,
+		RttWindowTimeout: 5 * time.Second,
+		AckTimeout:       30 * time.Second,
+		IdleTimeout:      60 * time.Second,
 		// pause on resend for selectively acked messaged
 		SelectiveAckTimeout: 5 * time.Second,
 		SequenceBufferSize:  DefaultTransferBufferSize,
@@ -109,7 +109,7 @@ func DefaultSendBufferSettings() *SendBufferSettings {
 
 func DefaultReceiveBufferSettings() *ReceiveBufferSettings {
 	return &ReceiveBufferSettings{
-		GapTimeout: 60 * time.Second,
+		GapTimeout: 30 * time.Second,
 		// the receive idle timeout should be a bit longer than the send idle timeout
 		IdleTimeout:        120 * time.Second,
 		SequenceBufferSize: DefaultTransferBufferSize,
@@ -976,9 +976,9 @@ type SendBufferSettings struct {
 	CreateContractRetryInterval time.Duration
 
 	// resend timeout is the initial time between successive send attempts. Does linear backoff
-	MinResendInterval  time.Duration
-	MaxResendInterval  time.Duration
-	ResendBackoffScale float32
+	MinResendInterval time.Duration
+	MaxResendInterval time.Duration
+	// ResendBackoffScale float32
 
 	RttScale         float32
 	RttWindowSize    int
@@ -1552,9 +1552,7 @@ func (self *SendSequence) Run() {
 				}
 
 				item.sendCount += 1
-				// linear backoff
-				// itemResendTimeout := self.sendBufferSettings.ResendInterval
-				itemResendTimeout := time.Duration(float32(self.rttWindow.ScaledRtt()/time.Millisecond)*(1+self.sendBufferSettings.ResendBackoffScale*float32(item.sendCount))) * time.Millisecond
+				itemResendTimeout := self.rttWindow.ScaledRtt()
 				if itemAckTimeout <= itemResendTimeout {
 					item.resendTime = sendTime.Add(itemAckTimeout)
 				} else {

--- a/connect/transfer_contract_manager.go
+++ b/connect/transfer_contract_manager.go
@@ -374,6 +374,41 @@ func (self *ContractManager) contractError(contractError protocol.ContractError)
 	}
 }
 
+func (self *ContractManager) GetProvideSecretKeys() map[protocol.ProvideMode][]byte {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	return maps.Clone(self.provideSecretKeys)
+}
+
+func (self *ContractManager) LoadProvideSecretKeys(provideSecretKeys map[protocol.ProvideMode][]byte) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	for provideMode, provideSecretKey := range provideSecretKeys {
+		self.provideSecretKeys[provideMode] = provideSecretKey
+	}
+}
+
+func (self *ContractManager) InitProvideSecretKeys() {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	for i, _ := range protocol.ProvideMode_name {
+		provideMode := protocol.ProvideMode(i)
+		provideSecretKey, ok := self.provideSecretKeys[provideMode]
+		if !ok {
+			// generate a new key
+			provideSecretKey = make([]byte, 32)
+			_, err := rand.Read(provideSecretKey)
+			if err != nil {
+				panic(err)
+			}
+			self.provideSecretKeys[provideMode] = provideSecretKey
+		}
+	}
+}
+
 func (self *ContractManager) SetProvidePaused(providePaused bool) {
 	self.mutex.Lock()
 	defer self.mutex.Unlock()

--- a/connect/transfer_contract_manager.go
+++ b/connect/transfer_contract_manager.go
@@ -300,6 +300,7 @@ func (self *ContractManager) Receive(source TransferPath, frames []*protocol.Fra
 			}
 		}
 		for _, contractError := range contractErrors {
+			glog.Infof("[contract]error = %s\n", contractError)
 			c := func() {
 				self.contractError(contractError)
 			}
@@ -713,7 +714,12 @@ func (self *ContractManager) CreateContract(contractKey ContractKey, timeout tim
 			if err == nil {
 				self.Receive(SourceId(ControlId), resultFrames, protocol.ProvideMode_Network)
 			} else {
-				glog.Warningf("[contract]oob err = %s\n", err)
+				select {
+				case <-self.client.Done():
+					// no need to log warnings when the client closes
+				default:
+					glog.Infof("[contract]oob err = %s\n", err)
+				}
 			}
 		},
 	)

--- a/connect/transfer_contract_manager.go
+++ b/connect/transfer_contract_manager.go
@@ -178,7 +178,9 @@ func NewContractManager(
 		controlSyncProvide:         NewControlSync(ctx, client, "provide"),
 	}
 
-	go contractManager.providePing()
+	if client.ClientId() != ControlId {
+		go contractManager.providePing()
+	}
 
 	return contractManager
 }

--- a/connect/transfer_queue.go
+++ b/connect/transfer_queue.go
@@ -208,8 +208,6 @@ func (self *transferQueue[T]) PeekLast() T {
 	return self.maxHeap.PeekFirst()
 }
 
-// FIXME RemoveLast
-
 // heap.Interface
 
 func (self *transferQueue[T]) Push(x any) {
@@ -289,7 +287,7 @@ func (self *transferQueueMaxHeap[T]) Pop() any {
 	return item
 }
 
-// sort.Interface
+// `sort.Interface`
 
 func (self *transferQueueMaxHeap[T]) Len() int {
 	return len(self.orderedItems)

--- a/connect/transfer_rtt.go
+++ b/connect/transfer_rtt.go
@@ -134,7 +134,7 @@ func (self *RttWindow) scaledRtt(sendTime time.Time) time.Duration {
 
 	self.coalesce(sendTime)
 
-	useRtt := self.rtts.MinRtt()
+	useRtt := self.rtts.MeanRtt()
 	scaledRtt := min(
 		max(
 			time.Duration(float32(useRtt/time.Millisecond)*self.rttScale)*time.Millisecond,

--- a/connect/transfer_rtt.go
+++ b/connect/transfer_rtt.go
@@ -1,0 +1,222 @@
+package connect
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"container/heap"
+
+	"github.com/golang/glog"
+
+	"bringyour.com/protocol"
+)
+
+type rttWindowItem struct {
+	sendTime    time.Time
+	receiveTime time.Time
+	rtt         time.Duration
+
+	heapIndex int
+}
+
+func newRttWindowItem(sendTime time.Time, receiveTime time.Time) *rttWindowItem {
+	return &rttWindowItem{
+		sendTime:    sendTime,
+		receiveTime: receiveTime,
+		rtt:         receiveTime.Sub(sendTime),
+	}
+}
+
+type RttWindow struct {
+	windowTimeout time.Duration
+	rttScale      float32
+	minScaledRtt  time.Duration
+	maxScaledRtt  time.Duration
+
+	stateLock       sync.Mutex
+	window          []*rttWindowItem
+	windowTailIndex int
+	windowHeadIndex int
+
+	rtts *rttHeap
+}
+
+func NewRttWindow(
+	windowSize int,
+	windowTimeout time.Duration,
+	rttScale float32,
+	minScaledRtt time.Duration,
+	maxScaledRtt time.Duration,
+) *RttWindow {
+	if windowSize == 0 {
+		panic(fmt.Errorf("Window size must non-zero: %d", windowSize))
+	}
+	window := make([]*rttWindowItem, windowSize)
+
+	return &RttWindow{
+		windowTimeout:   windowTimeout,
+		rttScale:        rttScale,
+		minScaledRtt:    minScaledRtt,
+		maxScaledRtt:    maxScaledRtt,
+		window:          window,
+		windowTailIndex: 0,
+		windowHeadIndex: 0,
+		rtts:            newRttHeap(),
+	}
+}
+
+// must be called inside the state lock
+func (self *RttWindow) coalesce(windowTime time.Time) {
+	windowStartTime := windowTime.Add(-self.windowTimeout)
+	for self.windowTailIndex != self.windowHeadIndex {
+		item := self.window[self.windowTailIndex]
+		if !item.receiveTime.Before(windowStartTime) {
+			break
+		}
+		self.rtts.Remove(item)
+		self.window[self.windowTailIndex] = nil
+		self.windowTailIndex = (self.windowTailIndex + 1) % len(self.window)
+	}
+}
+
+func (self *RttWindow) OpenTag() *protocol.Tag {
+	return self.openTag(time.Now())
+}
+
+func (self *RttWindow) openTag(sendTime time.Time) *protocol.Tag {
+	// sendTime
+	return &protocol.Tag{
+		SendTime: uint64(sendTime.UnixMilli()),
+	}
+}
+
+func (self *RttWindow) CloseTag(tag *protocol.Tag) {
+	self.closeTag(tag, time.Now())
+}
+
+func (self *RttWindow) closeTag(tag *protocol.Tag, receiveTime time.Time) {
+	sendTime := time.UnixMilli(int64(tag.SendTime))
+	if receiveTime.Before(sendTime) {
+		// ignore
+		return
+	}
+
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.coalesce(receiveTime)
+
+	item := newRttWindowItem(
+		sendTime,
+		receiveTime,
+	)
+	self.rtts.Add(item)
+
+	if replaceItem := self.window[self.windowHeadIndex]; replaceItem != nil {
+		self.rtts.Remove(replaceItem)
+	}
+	self.window[self.windowHeadIndex] = item
+	self.windowHeadIndex = (self.windowHeadIndex + 1) % len(self.window)
+	if self.windowTailIndex == self.windowHeadIndex {
+		self.windowTailIndex = (self.windowTailIndex + 1) % len(self.window)
+	}
+}
+
+// min(max of window * scale, overall max)
+func (self *RttWindow) ScaledRtt() time.Duration {
+	return self.scaledRtt(time.Now())
+}
+
+func (self *RttWindow) scaledRtt(sendTime time.Time) time.Duration {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+
+	self.coalesce(sendTime)
+
+	useRtt := self.rtts.MinRtt()
+	scaledRtt := min(
+		max(
+			time.Duration(float32(useRtt/time.Millisecond)*self.rttScale)*time.Millisecond,
+			self.minScaledRtt,
+		),
+		self.maxScaledRtt,
+	)
+	glog.V(2).Infof("[rtt]scaled=%dms\n", scaledRtt/time.Millisecond)
+	return scaledRtt
+}
+
+type rttHeap struct {
+	items  []*rttWindowItem
+	netRtt time.Duration
+}
+
+// `heap` is a min heap
+func newRttHeap() *rttHeap {
+	h := &rttHeap{
+		items:  []*rttWindowItem{},
+		netRtt: time.Duration(0),
+	}
+	heap.Init(h)
+	return h
+}
+
+func (self *rttHeap) Add(item *rttWindowItem) {
+	heap.Push(self, item)
+	self.netRtt += item.rtt
+}
+
+func (self *rttHeap) Remove(item *rttWindowItem) {
+	heap.Remove(self, item.heapIndex)
+	self.netRtt -= item.rtt
+}
+
+func (self *rttHeap) MinRtt() time.Duration {
+	n := len(self.items)
+	if n == 0 {
+		return time.Duration(0)
+	}
+	maxItem := self.items[n-1]
+	return maxItem.rtt
+}
+
+func (self *rttHeap) MeanRtt() time.Duration {
+	n := len(self.items)
+	if n == 0 {
+		return 0
+	}
+	return self.netRtt / time.Duration(n)
+}
+
+// `heap.Interface`
+
+func (self *rttHeap) Len() int {
+	return len(self.items)
+}
+
+func (self *rttHeap) Less(i, j int) bool {
+	return self.items[i].rtt < self.items[j].rtt
+}
+
+func (self *rttHeap) Swap(i, j int) {
+	a := self.items[i]
+	b := self.items[j]
+	b.heapIndex = i
+	self.items[i] = b
+	a.heapIndex = j
+	self.items[j] = a
+}
+
+func (self *rttHeap) Push(x any) {
+	item := x.(*rttWindowItem)
+	item.heapIndex = len(self.items)
+	self.items = append(self.items, item)
+}
+
+func (self *rttHeap) Pop() any {
+	n := len(self.items)
+	item := self.items[n-1]
+	self.items[n-1] = nil
+	self.items = self.items[0 : n-1]
+	return item
+}

--- a/connect/transfer_rtt_test.go
+++ b/connect/transfer_rtt_test.go
@@ -1,0 +1,57 @@
+package connect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-playground/assert/v2"
+)
+
+func TestRttWindow(t *testing.T) {
+	rttWindow := NewRttWindow(4, 1*time.Second, 1.0, 0, time.Second)
+
+	assert.Equal(t, rttWindow.ScaledRtt(), time.Duration(0))
+
+	start := time.Now()
+
+	tag1 := rttWindow.openTag(start)
+	tag2 := rttWindow.openTag(start.Add(50 * time.Millisecond))
+	tag3 := rttWindow.openTag(start.Add(100 * time.Millisecond))
+	tag4 := rttWindow.openTag(start.Add(150 * time.Millisecond))
+
+	assert.Equal(t, rttWindow.scaledRtt(start.Add(150*time.Millisecond)), time.Duration(0))
+
+	rttWindow.closeTag(tag2, start.Add(300*time.Millisecond)) // 250
+
+	assert.Equal(t, rttWindow.ScaledRtt(), 250*time.Millisecond)
+
+	rttWindow.closeTag(tag4, start.Add(300*time.Millisecond)) // 150
+	rttWindow.closeTag(tag3, start.Add(500*time.Millisecond)) // 400
+	rttWindow.closeTag(tag1, start.Add(800*time.Millisecond)) // 800
+
+	assert.Equal(t, rttWindow.scaledRtt(start.Add(800*time.Millisecond)), (250+150+400+800)/4*time.Millisecond)
+
+	start2 := start.Add(2 * time.Second)
+	tag21 := rttWindow.openTag(start2)
+	tag22 := rttWindow.openTag(start2)
+	tag23 := rttWindow.openTag(start2)
+	tag24 := rttWindow.openTag(start2)
+	tag25 := rttWindow.openTag(start2)
+
+	// clears the window
+	rttWindow.closeTag(tag21, start2.Add(500*time.Millisecond))
+
+	assert.Equal(t, rttWindow.scaledRtt(start2.Add(500*time.Millisecond)), 500*time.Millisecond)
+
+	rttWindow.closeTag(tag22, start2.Add(500*time.Millisecond))
+
+	assert.Equal(t, rttWindow.scaledRtt(start2.Add(500*time.Millisecond)), 500*time.Millisecond)
+
+	rttWindow.closeTag(tag23, start2.Add(500*time.Millisecond))
+	rttWindow.closeTag(tag24, start2.Add(500*time.Millisecond))
+
+	// cycle window
+	rttWindow.closeTag(tag25, start2.Add(100*time.Millisecond))
+
+	assert.Equal(t, rttWindow.scaledRtt(start2.Add(100*time.Millisecond)), (500+500+500+100)/4*time.Millisecond)
+}

--- a/connect/transfer_test.go
+++ b/connect/transfer_test.go
@@ -61,9 +61,14 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	clientSettingsA := DefaultClientSettings()
 	clientSettingsA.SendBufferSettings.SequenceBufferSize = 0
 	clientSettingsA.SendBufferSettings.AckBufferSize = 0
+	clientSettingsA.SendBufferSettings.AckTimeout = 90 * time.Second
+	clientSettingsA.SendBufferSettings.IdleTimeout = 180 * time.Second
 	clientSettingsA.ReceiveBufferSettings.SequenceBufferSize = 0
+	clientSettingsA.ReceiveBufferSettings.GapTimeout = 90 * time.Second
+	clientSettingsA.ReceiveBufferSettings.IdleTimeout = 180 * time.Second
 	// clientSettingsA.ReceiveBufferSettings.AckBufferSize = 0
 	clientSettingsA.ForwardBufferSettings.SequenceBufferSize = 0
+	clientSettingsA.ForwardBufferSettings.IdleTimeout = 180 * time.Second
 	a := NewClient(ctx, aClientId, NewNoContractClientOob(), clientSettingsA)
 	aRouteManager := a.RouteManager()
 	aContractManager := a.ContractManager()
@@ -81,9 +86,14 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	clientSettingsB := DefaultClientSettings()
 	clientSettingsB.SendBufferSettings.SequenceBufferSize = 0
 	clientSettingsB.SendBufferSettings.AckBufferSize = 0
+	clientSettingsB.SendBufferSettings.AckTimeout = 90 * time.Second
+	clientSettingsB.SendBufferSettings.IdleTimeout = 180 * time.Second
 	clientSettingsB.ReceiveBufferSettings.SequenceBufferSize = 0
+	clientSettingsB.ReceiveBufferSettings.GapTimeout = 90 * time.Second
+	clientSettingsB.ReceiveBufferSettings.IdleTimeout = 180 * time.Second
 	// clientSettingsB.ReceiveBufferSettings.AckBufferSize = 0
 	clientSettingsB.ForwardBufferSettings.SequenceBufferSize = 0
+	clientSettingsB.ForwardBufferSettings.IdleTimeout = 180 * time.Second
 	b := NewClient(ctx, bClientId, NewNoContractClientOob(), clientSettingsB)
 	bRouteManager := b.RouteManager()
 	bContractManager := b.ContractManager()
@@ -179,7 +189,12 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	aRouteManager.RemoveTransport(aSendTransport)
 	aRouteManager.RemoveTransport(aReceiveTransport)
 
-	a2 := NewClientWithDefaults(ctx, aClientId, NewNoContractClientOob())
+	select {
+	case <-time.After(1 * time.Second):
+	}
+
+	a2 := NewClient(ctx, aClientId, NewNoContractClientOob(), clientSettingsA)
+	// a2 := NewClientWithDefaults(ctx, aClientId, NewNoContractClientOob())
 	a2RouteManager := a2.RouteManager()
 	a2ContractManager := a2.ContractManager()
 	// a2RouteManager := NewRouteManager(a2)

--- a/connect/transfer_test.go
+++ b/connect/transfer_test.go
@@ -22,7 +22,7 @@ func TestSendReceiveSenderReset(t *testing.T) {
 	// The receiver should be able to reset using the new sequence_id
 
 	// timeout between receives or acks
-	timeout := 30 * time.Second
+	timeout := 60 * time.Second
 	// number of messages
 	n := 16 * 1024
 

--- a/protocol/transfer.proto
+++ b/protocol/transfer.proto
@@ -66,8 +66,8 @@ message Pack {
     optional Frame contract_frame = 7;
 
     // this is threaded back by the `Ack`
-    // so that the client can compute a single message rtt using `now()-ack.SendTime`
-    optional uint64 SendTime = 8;
+    // so that the client can compute a single message rtt
+    optional Tag tag = 8;
 }
 
 
@@ -86,8 +86,13 @@ message Ack {
     // all data buffered in the receiver is acked with `selective=true`. When released it is acked with `selective=false`
     bool selective = 3;
 
-    // the send time from the `Pack` this responds to
-    optional uint64 SendTime = 4;
+    // from the `Pack` this responds to
+    optional Tag tag = 4;
+}
+
+
+message Tag {
+    uint64 send_time = 1;
 }
 
 

--- a/protocol/transfer.proto
+++ b/protocol/transfer.proto
@@ -64,6 +64,10 @@ message Pack {
     bool nack = 6;
 
     optional Frame contract_frame = 7;
+
+    // this is threaded back by the `Ack`
+    // so that the client can compute a single message rtt using `now()-ack.SendTime`
+    optional uint64 SendTime = 8;
 }
 
 
@@ -81,6 +85,9 @@ message Ack {
     bytes sequence_id = 2;
     // all data buffered in the receiver is acked with `selective=true`. When released it is acked with `selective=false`
     bool selective = 3;
+
+    // the send time from the `Pack` this responds to
+    optional uint64 SendTime = 4;
 }
 
 


### PR DESCRIPTION
Address window scaling and rtt issues. 

- implement window scaling in `ip`
- delay retransmit timeout when rtt is bad. This prevents flooding the network.
- save and load contract manager keys
