### PR TITLE
nack fixes

### DIFF
--- a/connect/connect.go
+++ b/connect/connect.go
@@ -221,15 +221,19 @@ func (self Id) Bytes() []byte {
 }
 
 func (self Id) LessThan(b Id) bool {
+	return self.Cmp(b) < 0
+}
+
+func (self Id) Cmp(b Id) int {
 	for i, v := range self {
 		if v < b[i] {
-			return true
+			return -1
 		}
 		if b[i] < v {
-			return false
+			return 1
 		}
 	}
-	return false
+	return 0
 }
 
 func (self Id) String() string {

--- a/connect/transfer_contract_manager.go
+++ b/connect/transfer_contract_manager.go
@@ -881,13 +881,13 @@ func (self *ContractManager) closeContractQueueWithForceRemove(contractKey Contr
 	defer self.mutex.Unlock()
 
 	contractQueue, ok := self.destinationContracts[contractKey]
-	if !ok {
-		panic("Open and close must be equally paired")
+	if ok {
+		contractQueue.Close()
+		if contractQueue.IsDone() || forceRemove {
+			delete(self.destinationContracts, contractKey)
+		}
 	}
-	contractQueue.Close()
-	if contractQueue.IsDone() || forceRemove {
-		delete(self.destinationContracts, contractKey)
-	}
+	// else the contract was already force removed
 }
 
 type contractQueue struct {

--- a/protocol/transfer.proto
+++ b/protocol/transfer.proto
@@ -68,6 +68,11 @@ message Pack {
     // this is threaded back by the `Ack`
     // so that the client can compute a single message rtt
     optional Tag tag = 8;
+
+    // contract_id lock
+    // this is required for nack messages. There is no need to set this for ack messages.
+    // ulid
+    optional bytes contract_id = 9;
 }
 
 


### PR DESCRIPTION
Fix handing of nack messages and a few receiver contract issues.

The updated nack strategy is:

1. associate a nack message with an explicit contract
2. send nack messages as ack until the associated contract is acked, to avoid initial racing
3. the receiver maintains a window of contracts and uses the contract specified by the nack

Also fixes:
- idle timeout concurrency
- receive associate message with contract when the message is front of queue, not at receive
