### PR TITLE
multi: mark window as complete when the source pool is fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ client2-sim/client2-sim
 connect/connect.test
 connect.test
 connect/profile
+tether/tether.test
 profile
 .direnv/
 

--- a/ip_remote_multi_client_test.go
+++ b/ip_remote_multi_client_test.go
@@ -169,6 +169,10 @@ func (self *TestMultiClientGenerator) NewClient(ctx context.Context, args *Multi
 	return self.newClient(ctx, args, clientSettings)
 }
 
+func (self *TestMultiClientGenerator) FixedDestinationSize() (int, bool) {
+	return 0, false
+}
+
 func TestMultiClientChannelWindowStats(t *testing.T) {
 	// ensure that the bucket counts are bounded
 	// if this is broken, the coalesce logic is broken and there will be a memory issue


### PR DESCRIPTION
Mark window as stable when the source pool is fixed and the window is the max available. An important case of this is direct client connect.
