### PR TITLE
ip: update ReceivePacketFunction signature

### DIFF
--- a/ip_remote_multi_client_test.go
+++ b/ip_remote_multi_client_test.go
@@ -212,7 +212,7 @@ func TestMultiClientChannelWindowStats(t *testing.T) {
 		},
 	}
 
-	clientReceivePacket := func(client *multiClientChannel, source TransferPath, ipProtocol IpProtocol, packet []byte) {
+	clientReceivePacket := func(client *multiClientChannel, source TransferPath, provideMode protocol.ProvideMode, ipPath *IpPath, packet []byte) {
 		// Do nothing
 	}
 

--- a/ip_test.go
+++ b/ip_test.go
@@ -304,7 +304,7 @@ func testClient[P comparable](
 
 	receivePackets := make(chan *receivePacket)
 
-	receivePacketCallback := func(source TransferPath, ipProtocol IpProtocol, packet []byte) {
+	receivePacketCallback := func(source TransferPath, provideMode protocol.ProvideMode, ipPath *IpPath, packet []byte) {
 		// record the echo packet
 
 		// cMutex.Lock()


### PR DESCRIPTION
Expose full meta data of the packet, which is useful for end use cases. Missing pieces were provide mode (security relationship) of receive, and the full ip path of receive like version.