### PR TITLE
ip: security restrict bt trackers to reduce dht traffic

### DIFF
--- a/ip_security.go
+++ b/ip_security.go
@@ -122,9 +122,10 @@ func (self *SecurityPolicy) inspect(provideMode protocol.ProvideMode, packet []b
 			case port == 123, port == 500:
 				// apple system ports
 				return true
-			case 6881 <= port && port <= 6889:
+			case 6881 <= port && port <= 6889, port == 6969:
 				// bittorrent
 				return false
+
 			default:
 				return true
 			}


### PR DESCRIPTION
Some DHT activity has been detected on the network. Since the network does not allow file sharing, this is causing unnecessary noise.

Addresses https://github.com/urnetwork/connect/issues/85