### PR TITLE
Multi window tune

### DIFF
--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -1386,7 +1386,14 @@ func (self *multiClientWindow) resize() {
 					int(math.Ceil(self.settings.WindowExpandScale*float64(len(clients)))),
 				),
 			)
-			collapseWindowSize = int(math.Ceil(self.settings.WindowCollapseScale * float64(len(clients))))
+
+			collapseWindowSize = max(
+				self.settings.WindowSizeMin,
+				max(
+					self.settings.WindowSizeMin,
+					int(math.Ceil(self.settings.WindowCollapseScale*float64(len(clients)))),
+				),
+			)
 		}
 
 		collapseLowestWeighted := func(windowSize int) []*multiClientChannel {
@@ -1430,7 +1437,7 @@ func (self *multiClientWindow) resize() {
 		}
 		if expandWindowSize <= targetWindowSize && len(clients) < expandWindowSize || p2pOnlyWindowSize < self.settings.WindowSizeMinP2pOnly {
 			// collapse badly performing clients before expanding
-			removedClients := collapseLowestWeighted(0)
+			removedClients := collapseLowestWeighted(collapseWindowSize)
 			if 0 < len(removedClients) {
 				glog.Infof("[multi]window optimize -%d ->%d\n", len(removedClients), len(clients))
 				// for _, client := range removedClients {

--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -78,7 +78,7 @@ func DefaultMultiClientSettings() *MultiClientSettings {
 		WindowEnumerateEmptyTimeout:  60 * time.Second,
 		WindowEnumerateErrorTimeout:  1 * time.Second,
 		WindowExpandScale:            2.0,
-		WindowCollapseScale:          0.5,
+		WindowCollapseScale:          0.8,
 		WindowExpandMaxOvershotScale: 4.0,
 		WindowCollapseBeforeExpand:   false,
 		WindowRevisitTimeout:         2 * time.Minute,


### PR DESCRIPTION
Tune the multi window management algorithm.
- Visited providers should be eligible to be reconsidered after a timeout https://github.com/urnetwork/connect/issues/88
- Expanding the window should not collapse to zero. This is causing unnecessary provider churn. Explore no collapse at all on expansion to minimize churn.
