### PR TITLE
fix: linux install script does not work correctly with -t option 

### DIFF
--- a/scripts/Provider_Install_Linux.sh
+++ b/scripts/Provider_Install_Linux.sh
@@ -52,7 +52,7 @@ while [ $# -gt 0 ]; do
 
 	-t|--tag)
 	    require_arg "$1" "$2"
-	    tag="$2"
+	    tag="tags/$2"
 	    shift 2
 	    ;;
 

--- a/scripts/Provider_Install_Linux.sh
+++ b/scripts/Provider_Install_Linux.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 me="$0"
-SCRIPT_VERSION="1.0.0"
+SCRIPT_VERSION="1.0.1"
 
 if [ "$me" = "sh" ] || [ "$me" = "bash" ] || [ "$me" = "zsh" ]; then
     me="urnetwork-installer"


### PR DESCRIPTION
The current script sends a request to the `.../releases/{id}` endpoint of the GitHub API, but it expects the `id` to be a numeric release ID. This PR fixes this issue by using `.../releases/tags/{tag}` endpoint instead, when possible.