### PR TITLE
Download fallback for Windows installer script

### DIFF
--- a/scripts/Provider_Install_Win32.ps1
+++ b/scripts/Provider_Install_Win32.ps1
@@ -64,11 +64,18 @@ $FileName = $ReleaseAsset.name
 $FilePath = Join-Path -Path $env:TEMP -ChildPath $FileName
 
 Write-Host "Downloading $FileName from $DownloadUrl"
-Start-BitsTransfer -Source $DownloadUrl -Destination $FilePath
-
-if (!$?) {
-  Write-Error "Failed to download the release asset. Are you sure the version exists and your internet connection is working?"
-  exit 1
+try {
+    Start-BitsTransfer -Source $DownloadUrl -Destination $FilePath -ErrorAction Stop
+}
+catch {
+    Write-Warning "Something went wrong during the download process. Reattempting using different technique."
+    try {
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $FilePath -UseBasicParsing -ErrorAction Stop
+    }
+    catch {
+        Write-Error "Failed to download the release asset. Are you sure the version exists and your internet connection is working?"
+        exit 1
+    }
 }
 
 $InstallDir = Join-Path -Path $env:LOCALAPPDATA -ChildPath "urnetwork\provider"


### PR DESCRIPTION
For me personally, Start-BitsTransfer doesn't really work, so I've made a change that'll make the script fall back to Invoke-WebRequest.

It's slower, but it'll do the job if Start-BitsTransfer fails.