### PR TITLE
Provider proxy

### DIFF
--- a/net_extender.go
+++ b/net_extender.go
@@ -149,10 +149,21 @@ func NewExtenderDialTlsContext(
 		switch extenderConfig.Profile.ConnectMode {
 		case ExtenderConnectModeTcpTls:
 			netDialer := &net.Dialer{
-				Timeout: connectSettings.ConnectTimeout,
+				Timeout:  connectSettings.ConnectTimeout,
+				Resolver: connectSettings.Resolver,
 			}
 
-			conn, err := netDialer.Dial("tcp", authority)
+			var dialContext DialContextFunction
+			if connectSettings.ProxySettings != nil {
+				dialContext = connectSettings.ProxySettings.NewDialContext(
+					ctx,
+					netDialer,
+				)
+			} else {
+				dialContext = netDialer.DialContext
+			}
+
+			conn, err := dialContext(ctx, "tcp", authority)
 			if err != nil {
 				return nil, err
 			}

--- a/net_extender.go
+++ b/net_extender.go
@@ -148,20 +148,7 @@ func NewExtenderDialTlsContext(
 
 		switch extenderConfig.Profile.ConnectMode {
 		case ExtenderConnectModeTcpTls:
-			netDialer := &net.Dialer{
-				Timeout:  connectSettings.ConnectTimeout,
-				Resolver: connectSettings.Resolver,
-			}
-
-			var dialContext DialContextFunction
-			if connectSettings.ProxySettings != nil {
-				dialContext = connectSettings.ProxySettings.NewDialContext(
-					ctx,
-					netDialer,
-				)
-			} else {
-				dialContext = netDialer.DialContext
-			}
+			dialContext := connectSettings.NewDialContext(ctx)
 
 			conn, err := dialContext(ctx, "tcp", authority)
 			if err != nil {

--- a/net_http.go
+++ b/net_http.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/proxy"
+
 	"golang.org/x/net/nettest"
 
 	"golang.org/x/exp/maps"
@@ -36,6 +38,7 @@ import (
 type HttpPostRawFunction func(ctx context.Context, requestUrl string, requestBodyBytes []byte, byJwt string) ([]byte, error)
 type HttpGetRawFunction func(ctx context.Context, requestUrl string, byJwt string) ([]byte, error)
 
+type DialContextFunction = func(ctx context.Context, network string, addr string) (net.Conn, error)
 type DialTlsContextFunction = func(ctx context.Context, network string, addr string) (net.Conn, error)
 
 func DefaultClientStrategySettings() *ClientStrategySettings {
@@ -96,6 +99,40 @@ type ConnectSettings struct {
 	KeepAliveConfig  net.KeepAliveConfig
 
 	TlsConfig *tls.Config
+
+	ProxySettings *ProxySettings
+	Resolver      *net.Resolver
+}
+
+type ProxySettings struct {
+	Network string
+	Address string
+	Auth    *proxy.Auth
+}
+
+func (self *ProxySettings) NewDialContext(ctx context.Context, forward proxy.Dialer) DialContextFunction {
+	return func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		proxyDialer, err := proxy.SOCKS5(
+			self.Network,
+			self.Address,
+			self.Auth,
+			forward,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		var conn net.Conn
+		if v, ok := proxyDialer.(proxy.ContextDialer); ok {
+			conn, err = v.DialContext(ctx, network, addr)
+		} else {
+			conn, err = proxyDialer.Dial(network, addr)
+		}
+		if err != nil {
+			return nil, err
+		}
+		return conn, nil
+	}
 }
 
 type ClientStrategySettings struct {
@@ -164,20 +201,77 @@ func NewClientStrategy(ctx context.Context, settings *ClientStrategySettings) *C
 	if settings.EnableNormal {
 		// TODO ECH support
 		if settings.ExposeServerHostNames && settings.ExposeServerIps {
-			tlsDialer := &tls.Dialer{
-				NetDialer: &net.Dialer{
-					Timeout:         settings.ConnectTimeout,
-					KeepAlive:       settings.KeepAliveTimeout,
-					KeepAliveConfig: settings.KeepAliveConfig,
-				},
-				Config: settings.TlsConfig,
+			netDialer := &net.Dialer{
+				Timeout:         settings.ConnectTimeout,
+				KeepAlive:       settings.KeepAliveTimeout,
+				KeepAliveConfig: settings.KeepAliveConfig,
+				Resolver:        settings.Resolver,
+			}
+
+			var tlsDialContext DialTlsContextFunction
+			if settings.ProxySettings != nil {
+				tlsDialContext = func(ctx context.Context, network string, addr string) (net.Conn, error) {
+					proxyDialContext := settings.ProxySettings.NewDialContext(
+						ctx,
+						netDialer,
+					)
+
+					// this rest of this function is adapted from `tls.dial` to use a proxy dialer
+
+					conn, err := proxyDialContext(ctx, network, addr)
+					if err != nil {
+						return nil, err
+					}
+
+					if netDialer.Timeout != 0 {
+						var cancel context.CancelFunc
+						ctx, cancel = context.WithTimeout(ctx, netDialer.Timeout)
+						defer cancel()
+					}
+
+					if !netDialer.Deadline.IsZero() {
+						var cancel context.CancelFunc
+						ctx, cancel = context.WithDeadline(ctx, netDialer.Deadline)
+						defer cancel()
+					}
+
+					colonPos := strings.LastIndex(addr, ":")
+					if colonPos == -1 {
+						colonPos = len(addr)
+					}
+					hostname := addr[:colonPos]
+
+					tlsConfig := settings.TlsConfig
+					if tlsConfig == nil {
+						// `tls.defaultConfig`
+						tlsConfig = &tls.Config{}
+					}
+					if tlsConfig.ServerName == "" {
+						c := tlsConfig.Clone()
+						c.ServerName = hostname
+						tlsConfig = c
+					}
+
+					tlsConn := tls.Client(conn, tlsConfig)
+					if err := tlsConn.HandshakeContext(ctx); err != nil {
+						conn.Close()
+						return nil, err
+					}
+					return tlsConn, nil
+				}
+			} else {
+				tlsDialer := &tls.Dialer{
+					NetDialer: netDialer,
+					Config:    settings.TlsConfig,
+				}
+				tlsDialContext = tlsDialer.DialContext
 			}
 
 			dialer := &clientDialer{
 				description:    "normal",
 				minimumWeight:  0.5,
 				priority:       25,
-				dialTlsContext: tlsDialer.DialContext,
+				dialTlsContext: tlsDialContext,
 				settings:       settings,
 			}
 			dialers[dialer] = true

--- a/net_http_doh.go
+++ b/net_http_doh.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
+	// "net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -62,20 +62,7 @@ func DohQuery(ctx context.Context, ipVersion int, recordType string, settings *D
 		return map[netip.Addr]bool{}
 	}
 
-	netDialer := &net.Dialer{
-		Timeout:  settings.ConnectTimeout,
-		Resolver: settings.Resolver,
-	}
-
-	var dialContext DialContextFunction
-	if settings.ProxySettings != nil {
-		dialContext = settings.ProxySettings.NewDialContext(
-			ctx,
-			netDialer,
-		)
-	} else {
-		dialContext = netDialer.DialContext
-	}
+	dialContext := settings.NewDialContext(ctx)
 
 	httpClient := &http.Client{
 		Timeout: settings.RequestTimeout,

--- a/net_resilient.go
+++ b/net_resilient.go
@@ -43,9 +43,6 @@ import (
 
 // see https://upb-syssec.github.io/blog/2023/record-fragmentation/
 
-// (ctx, network, address)
-// type DialContextFunc func(ctx context.Context, network string, address string) (net.Conn, error)
-
 // set this as the `DialTLSContext` or equivalent
 // returns a tls connection
 func NewResilientDialTlsContext(
@@ -69,12 +66,9 @@ func NewResilientDialTlsContext(
 
 		// fmt.Printf("Extender client 1\n")
 
-		netDialer := &net.Dialer{
-			Timeout:         connectSettings.ConnectTimeout,
-			KeepAlive:       connectSettings.KeepAliveTimeout,
-			KeepAliveConfig: connectSettings.KeepAliveConfig,
-		}
-		conn, err := netDialer.Dial("tcp", address)
+		dialContext := connectSettings.NewDialContext(ctx)
+
+		conn, err := dialContext(ctx, "tcp", address)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/Makefile
+++ b/provider/Makefile
@@ -6,18 +6,18 @@ clean:
 	rm -rf build
 
 build:
-	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/arm64/
-	env CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/arm/
-	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/amd64/
-	env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/386/
-	env CGO_ENABLED=0 GOOS=linux GOARCH=mips GOMIPS=softfloat go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/mips/
-	env CGO_ENABLED=0 GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -trimpath -ldflags "-w -s -w -s -X main.Version=${WARP_VERSION}" -o build/linux/mipsle/
-	env CGO_ENABLED=0 GOOS=linux GOARCH=mips64 GOMIPS=softfloat go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/mips64/
-	env CGO_ENABLED=0 GOOS=linux GOARCH=mips64le GOMIPS=softfloat go build -trimpath -ldflags "-w -s -w -s -X main.Version=${WARP_VERSION}" -o build/linux/mips64le/
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/darwin/arm64/
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/darwin/amd64/
-	env CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/windows/arm64/
-	env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/windows/amd64/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/arm64/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/arm/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/amd64/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/386/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=linux GOARCH=mips GOMIPS=softfloat go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/mips/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -trimpath -ldflags "-w -s -w -s -X main.Version=${WARP_VERSION}" -o build/linux/mipsle/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=linux GOARCH=mips64 GOMIPS=softfloat go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/linux/mips64/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=linux GOARCH=mips64le GOMIPS=softfloat go build -trimpath -ldflags "-w -s -w -s -X main.Version=${WARP_VERSION}" -o build/linux/mips64le/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/darwin/arm64/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/darwin/amd64/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/windows/arm64/
+	env GOEXPERIMENT=greenteagc CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-w -s -X main.Version=${WARP_VERSION}" -o build/windows/amd64/
 	tar -czf build/provider.tar.gz -C build linux darwin windows
 
 warp_build:


### PR DESCRIPTION
Add support for SOCKS5 proxies in the connect network and the provider binary.

The provider binary supports new commands:

```
    provider proxy auth add [<key>] <proxy_user> <proxy_password> [-f]
    provider proxy auth remove [<key>]
    provider proxy add <key_address>... [-f]
    provider proxy remove <key_address>...

    <key>                            Authentication key
    <proxy_user>                     The SOCKS5 user per RFC 1928/1929
    <proxy_password>                 The SOCKS5 password per RFC 1928/1929
    <key_address>                    SOCKS5 server as host:port or key@host:port`,
```

A SOCKS5 auth (RFC 1928/1929) is associated with a key, and each server is associated with a key. If there is only one authentication across all servers, the key can be omitted. 

e.g.

```
provider proxy auth add free d0m
provider proxy add 1.2.3.4:4009
provider proxy add 1.2.3.4:4010
```
