### PR TITLE
udp: use ack for udp transfer between client and provider

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -2553,11 +2553,7 @@ func (self *RemoteUserNatProvider) Receive(
 	opts := []any{
 		CompanionContract(),
 	}
-	switch ipPath.Protocol {
-	case IpProtocolUdp:
-		opts = append(opts, NoAck())
-	}
-
+	// note udp is sent with ack because because otherwise the delivery reliability will mulitply with the egress
 	c := func() bool {
 		// ack := make(chan error)
 		sent := self.client.SendWithTimeout(
@@ -2761,10 +2757,7 @@ func (self *RemoteUserNatClient) SendPacket(source TransferPath, provideMode pro
 
 		// the sender will control transfer
 		opts := []any{}
-		switch ipPath.Protocol {
-		case IpProtocolUdp:
-			opts = append(opts, NoAck())
-		}
+		// note udp is sent with ack because because otherwise the delivery reliability will mulitply with the egress
 		success := self.client.SendMultiHopWithTimeout(frame, destination, func(err error) {}, timeout, opts...)
 		return success
 	case SecurityPolicyResultDrop:

--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -181,6 +181,7 @@ func DefaultMultiClientSettings() *MultiClientSettings {
 		DefaultUlimit:         0,
 
 		TcpCollapsePrevention: true,
+		UdpCollapsePrevention: false,
 
 		IngressSecurityPolicyGenerator: DefaultIngressSecurityPolicyWithStats,
 		EgressSecurityPolicyGenerator:  DefaultEgressSecurityPolicyWithStats,
@@ -267,6 +268,7 @@ type MultiClientSettings struct {
 	DefaultUlimit int
 
 	TcpCollapsePrevention bool
+	UdpCollapsePrevention bool
 
 	IngressSecurityPolicyGenerator func(*SecurityPolicyStatsCollector) SecurityPolicy
 	EgressSecurityPolicyGenerator  func(*SecurityPolicyStatsCollector) SecurityPolicy
@@ -2775,7 +2777,11 @@ func (self *multiClientChannel) SendDetailed(parsedPacket *parsedPacket, timeout
 	var ack bool
 	switch parsedPacket.ipPath.Protocol {
 	case IpProtocolUdp:
-		ack = false
+		if self.settings.UdpCollapsePrevention {
+			ack = false
+		} else {
+			ack = true
+		}
 	default:
 		ack = true
 	}


### PR DESCRIPTION
Otherwise unreliability will multiply.