### PR TITLE
perf: increase InitialContractTransferByteCount to 256KiB

### DIFF
--- a/transfer_contract_manager.go
+++ b/transfer_contract_manager.go
@@ -85,7 +85,7 @@ func DefaultContractManagerSettings() *ContractManagerSettings {
 		panic(err)
 	}
 	return &ContractManagerSettings{
-		InitialContractTransferByteCount:  kib(16),
+		InitialContractTransferByteCount:  kib(256),
 		StandardContractTransferByteCount: mib(128),
 		ContractTransferByteSeqScale:      4,
 

--- a/transfer_contract_manager.go
+++ b/transfer_contract_manager.go
@@ -195,7 +195,7 @@ func DefaultContractManagerSettingsWithBufferSize(bufferSize int) *ContractManag
 	}
 	return &ContractManagerSettings{
 		SequenceBufferSize:                bufferSize,
-		InitialContractTransferByteCount:  kib(16),
+		InitialContractTransferByteCount:  kib(256),
 		StandardContractTransferByteCount: mib(128),
 		ContractTransferByteSeqScale:      4,
 


### PR DESCRIPTION
Increases the initial contract size to reduce negotiation overhead. At the current 16KiB limit, the 80% `ContractFillFraction` threshold (~13KB) is often too small to accommodate a final ~1.4KB packet, leading to frequent contract exhaustion logs and performance bottlenecks.

This issue was originally investigated and reported by UnicoreX (Kevin) in the community Discord. Their analysis correctly identified the `InitialContractTransferByteCount` bottleneck for provider throughput. 

Link to original bug report: https://discord.com/channels/807713145006850048/1412465917765353472/1496715109198729216