### PR TITLE
contract,transport: reduce log spam during backend outages

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	// "runtime/debug"
@@ -22,6 +23,26 @@ import (
 
 	"github.com/urnetwork/connect/protocol"
 )
+
+var (
+	lastDropErrLogNano     atomic.Int64
+	suppressedDropErrCount atomic.Int64
+)
+
+func shouldLogDropErr() (bool, int64) {
+	now := time.Now().UnixNano()
+	last := lastDropErrLogNano.Load()
+	if now-last < int64(time.Minute) {
+		suppressedDropErrCount.Add(1)
+		return false, 0
+	}
+	if !lastDropErrLogNano.CompareAndSwap(last, now) {
+		suppressedDropErrCount.Add(1)
+		return false, 0
+	}
+	suppressed := suppressedDropErrCount.Swap(0)
+	return true, suppressed
+}
 
 /*
 Sends frames to destinations with properties:
@@ -3631,7 +3652,13 @@ func (self *ReceiveSequence) Run() {
 			} else {
 				err := c()
 				if err != nil {
-					self.log.Infof("[r]drop = %s", err)
+					if ok, suppressed := shouldLogDropErr(); ok {
+						if suppressed > 0 {
+							self.log.Infof("[r]drop = %s (%d suppressed)", err, suppressed)
+						} else {
+							self.log.Infof("[r]drop = %s", err)
+						}
+					}
 				}
 			}
 		}

--- a/transfer_contract_manager.go
+++ b/transfer_contract_manager.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	// "errors"
@@ -21,6 +22,24 @@ import (
 
 	"github.com/urnetwork/connect/protocol"
 )
+
+var lastOobErrLogNano atomic.Int64
+var suppressedOobErrCount atomic.Int64
+
+func shouldLogOobErr() (bool, int64) {
+	now := time.Now().UnixNano()
+	last := lastOobErrLogNano.Load()
+	if now-last < int64(time.Minute) {
+		suppressedOobErrCount.Add(1)
+		return false, 0
+	}
+	if !lastOobErrLogNano.CompareAndSwap(last, now) {
+		suppressedOobErrCount.Add(1)
+		return false, 0
+	}
+	suppressed := suppressedOobErrCount.Swap(0)
+	return true, suppressed
+}
 
 // manage contracts which are embedded into each transfer sequence
 
@@ -324,19 +343,17 @@ func (self *ContractManager) createContractOobErrorBackoffActive() bool {
 	return time.Now().Before(self.createContractOobErrorBackoffUntil)
 }
 
-func (self *ContractManager) markCreateContractOobError() bool {
+func (self *ContractManager) markCreateContractOobError() {
 	if self.settings.CreateContractOobErrorBackoff <= 0 {
-		return true
+		return
 	}
 
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
 
-	if time.Now().Before(self.createContractOobErrorBackoffUntil) {
-		return false
+	if !time.Now().Before(self.createContractOobErrorBackoffUntil) {
+		self.createContractOobErrorBackoffUntil = time.Now().Add(self.settings.CreateContractOobErrorBackoff)
 	}
-	self.createContractOobErrorBackoffUntil = time.Now().Add(self.settings.CreateContractOobErrorBackoff)
-	return true
 }
 
 func NewContractManager(
@@ -1130,8 +1147,13 @@ func (self *ContractManager) CreateContract(contractKey ContractKey, contractSeq
 				case <-self.client.Done():
 					// no need to log warnings when the client closes
 				default:
-					if self.markCreateContractOobError() {
-						self.client.log.Infof("[contract]oob err = %s; backing off create contract OOB requests for %s\n", err, self.settings.CreateContractOobErrorBackoff)
+					self.markCreateContractOobError()
+					if ok, suppressed := shouldLogOobErr(); ok {
+						if suppressed > 0 {
+							self.client.log.Infof("[contract]oob err = %s; backing off create contract OOB requests for %s (%d suppressed)\n", err, self.settings.CreateContractOobErrorBackoff, suppressed)
+						} else {
+							self.client.log.Infof("[contract]oob err = %s; backing off create contract OOB requests for %s\n", err, self.settings.CreateContractOobErrorBackoff)
+						}
 					}
 				}
 			}

--- a/transfer_contract_manager.go
+++ b/transfer_contract_manager.go
@@ -324,15 +324,19 @@ func (self *ContractManager) createContractOobErrorBackoffActive() bool {
 	return time.Now().Before(self.createContractOobErrorBackoffUntil)
 }
 
-func (self *ContractManager) markCreateContractOobError() {
+func (self *ContractManager) markCreateContractOobError() bool {
 	if self.settings.CreateContractOobErrorBackoff <= 0 {
-		return
+		return true
 	}
 
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
 
+	if time.Now().Before(self.createContractOobErrorBackoffUntil) {
+		return false
+	}
 	self.createContractOobErrorBackoffUntil = time.Now().Add(self.settings.CreateContractOobErrorBackoff)
+	return true
 }
 
 func NewContractManager(
@@ -1126,8 +1130,9 @@ func (self *ContractManager) CreateContract(contractKey ContractKey, contractSeq
 				case <-self.client.Done():
 					// no need to log warnings when the client closes
 				default:
-					self.markCreateContractOobError()
-					self.client.log.Infof("[contract]oob err = %s; backing off create contract OOB requests for %s\n", err, self.settings.CreateContractOobErrorBackoff)
+					if self.markCreateContractOobError() {
+						self.client.log.Infof("[contract]oob err = %s; backing off create contract OOB requests for %s\n", err, self.settings.CreateContractOobErrorBackoff)
+					}
 				}
 			}
 		},

--- a/transfer_contract_manager.go
+++ b/transfer_contract_manager.go
@@ -206,6 +206,8 @@ func DefaultContractManagerSettingsWithBufferSize(bufferSize int) *ContractManag
 
 		ContractQueueExpireTimeout: 120 * time.Second,
 
+		CreateContractOobErrorBackoff: time.Minute,
+
 		ProtocolVersion: DefaultProtocolVersion,
 
 		// TODO remove
@@ -259,6 +261,10 @@ type ContractManagerSettings struct {
 	// window (5 minutes). <= 0 disables expiry.
 	ContractQueueExpireTimeout time.Duration
 
+	// back off create-contract OOB API calls after an OOB error to avoid
+	// repeatedly hitting the API while it is timing out or unavailable.
+	CreateContractOobErrorBackoff time.Duration
+
 	ProtocolVersion int
 
 	// TODO remove
@@ -299,10 +305,34 @@ type ContractManager struct {
 
 	controlSyncProvide    *ControlSync
 	controlSyncProvideOob *ControlSyncOob
+
+	createContractOobErrorBackoffUntil time.Time
 }
 
 func NewContractManagerWithDefaults(ctx context.Context, client *Client) *ContractManager {
 	return NewContractManager(ctx, client, DefaultContractManagerSettings())
+}
+
+func (self *ContractManager) createContractOobErrorBackoffActive() bool {
+	if self.settings.CreateContractOobErrorBackoff <= 0 {
+		return false
+	}
+
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	return time.Now().Before(self.createContractOobErrorBackoffUntil)
+}
+
+func (self *ContractManager) markCreateContractOobError() {
+	if self.settings.CreateContractOobErrorBackoff <= 0 {
+		return
+	}
+
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	self.createContractOobErrorBackoffUntil = time.Now().Add(self.settings.CreateContractOobErrorBackoff)
 }
 
 func NewContractManager(
@@ -1055,6 +1085,10 @@ func (self *ContractManager) addContract(contractKey ContractKey, contract *prot
 }
 
 func (self *ContractManager) CreateContract(contractKey ContractKey, contractSeqIndex uint64, minByteCount ByteCount) {
+	if self.createContractOobErrorBackoffActive() {
+		return
+	}
+
 	// look at destinationContracts and last contract to get previous contract id
 	contractQueue := self.openContractQueue(contractKey)
 	defer self.closeContractQueue(contractKey)
@@ -1092,7 +1126,8 @@ func (self *ContractManager) CreateContract(contractKey ContractKey, contractSeq
 				case <-self.client.Done():
 					// no need to log warnings when the client closes
 				default:
-					self.client.log.Infof("[contract]oob err = %s\n", err)
+					self.markCreateContractOobError()
+					self.client.log.Infof("[contract]oob err = %s; backing off create contract OOB requests for %s\n", err, self.settings.CreateContractOobErrorBackoff)
 				}
 			}
 		},

--- a/transport.go
+++ b/transport.go
@@ -186,6 +186,9 @@ type PlatformTransport struct {
 	availableModes map[TransportMode]bool
 	targetMode     TransportMode
 	mode           TransportMode
+
+	authErrMu      sync.Mutex
+	lastAuthErrLog time.Time
 }
 
 func NewPlatformTransportWithDefaults(
@@ -390,6 +393,16 @@ func isBetterMode(current TransportMode, other TransportMode) bool {
 	return transportModePreferences[current] < transportModePreferences[other]
 }
 
+func (self *PlatformTransport) shouldLogAuthErr() bool {
+	self.authErrMu.Lock()
+	defer self.authErrMu.Unlock()
+	if time.Since(self.lastAuthErrLog) < time.Minute {
+		return false
+	}
+	self.lastAuthErrLog = time.Now()
+	return true
+}
+
 func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 	// connect and update route manager for this transport
 	defer self.cancel()
@@ -495,7 +508,7 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 			ws, err = connect()
 		}
 		if err != nil {
-			if !authErrLogged {
+			if !authErrLogged && self.shouldLogAuthErr() {
 				self.log.Infof("[t]auth error %s = %s\n", clientId, err)
 				authErrLogged = true
 			} else {
@@ -1087,7 +1100,7 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 			connStream, err = connect()
 		}
 		if err != nil {
-			if !authErrLogged {
+			if !authErrLogged && self.shouldLogAuthErr() {
 				self.log.Infof("[t]auth error %s = %s\n", clientId, err)
 				authErrLogged = true
 			} else {

--- a/transport.go
+++ b/transport.go
@@ -404,6 +404,7 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 		}
 	}
 
+	authErrLogged := false
 	for {
 		// wait until we are back in h1 or worse
 		func() {
@@ -494,7 +495,12 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 			ws, err = connect()
 		}
 		if err != nil {
-			self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+			if !authErrLogged {
+				self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+				authErrLogged = true
+			} else {
+				self.log.V(1).Infof("[t]auth error %s = %s\n", clientId, err)
+			}
 			select {
 			case <-self.ctx.Done():
 				return
@@ -502,6 +508,7 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 				continue
 			}
 		}
+		authErrLogged = false
 
 		c := func() {
 			defer ws.Close()
@@ -900,6 +907,7 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 		}
 	}
 
+	authErrLogged := false
 	for {
 		// wait until we are back in the specific pt mode or auto mode
 		func() {
@@ -1079,7 +1087,12 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 			connStream, err = connect()
 		}
 		if err != nil {
-			self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+			if !authErrLogged {
+				self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+				authErrLogged = true
+			} else {
+				self.log.V(1).Infof("[t]auth error %s = %s\n", clientId, err)
+			}
 			select {
 			case <-self.ctx.Done():
 				return
@@ -1087,6 +1100,7 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 				continue
 			}
 		}
+		authErrLogged = false
 		conn := connStream.conn
 		stream := connStream.stream
 

--- a/transport.go
+++ b/transport.go
@@ -187,8 +187,6 @@ type PlatformTransport struct {
 	targetMode     TransportMode
 	mode           TransportMode
 
-	authErrMu      sync.Mutex
-	lastAuthErrLog time.Time
 }
 
 func NewPlatformTransportWithDefaults(
@@ -393,14 +391,27 @@ func isBetterMode(current TransportMode, other TransportMode) bool {
 	return transportModePreferences[current] < transportModePreferences[other]
 }
 
-func (self *PlatformTransport) shouldLogAuthErr() bool {
-	self.authErrMu.Lock()
-	defer self.authErrMu.Unlock()
-	if time.Since(self.lastAuthErrLog) < time.Minute {
-		return false
+// lastAuthErrLogNano and suppressedAuthErrCount are package-level atomics shared
+// across all PlatformTransport instances, rate-limiting [t]auth error log lines to
+// at most once per minute and tracking how many were suppressed in the interval.
+var lastAuthErrLogNano atomic.Int64
+var suppressedAuthErrCount atomic.Int64
+
+// shouldLogAuthErr returns (true, suppressedCount) if a log line should be emitted,
+// resetting the suppressed counter. Returns (false, 0) if the error is suppressed.
+func shouldLogAuthErr() (bool, int64) {
+	now := time.Now().UnixNano()
+	last := lastAuthErrLogNano.Load()
+	if now-last < int64(time.Minute) {
+		suppressedAuthErrCount.Add(1)
+		return false, 0
 	}
-	self.lastAuthErrLog = time.Now()
-	return true
+	if !lastAuthErrLogNano.CompareAndSwap(last, now) {
+		suppressedAuthErrCount.Add(1)
+		return false, 0
+	}
+	suppressed := suppressedAuthErrCount.Swap(0)
+	return true, suppressed
 }
 
 func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
@@ -508,9 +519,17 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 			ws, err = connect()
 		}
 		if err != nil {
-			if !authErrLogged && self.shouldLogAuthErr() {
-				self.log.Infof("[t]auth error %s = %s\n", clientId, err)
-				authErrLogged = true
+			if !authErrLogged {
+				if ok, suppressed := shouldLogAuthErr(); ok {
+					if suppressed > 0 {
+						self.log.Infof("[t]auth error %s = %s (%d suppressed)\n", clientId, err, suppressed)
+					} else {
+						self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+					}
+					authErrLogged = true
+				} else {
+					self.log.V(1).Infof("[t]auth error %s = %s\n", clientId, err)
+				}
 			} else {
 				self.log.V(1).Infof("[t]auth error %s = %s\n", clientId, err)
 			}
@@ -1100,9 +1119,17 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 			connStream, err = connect()
 		}
 		if err != nil {
-			if !authErrLogged && self.shouldLogAuthErr() {
-				self.log.Infof("[t]auth error %s = %s\n", clientId, err)
-				authErrLogged = true
+			if !authErrLogged {
+				if ok, suppressed := shouldLogAuthErr(); ok {
+					if suppressed > 0 {
+						self.log.Infof("[t]auth error %s = %s (%d suppressed)\n", clientId, err, suppressed)
+					} else {
+						self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+					}
+					authErrLogged = true
+				} else {
+					self.log.V(1).Infof("[t]auth error %s = %s\n", clientId, err)
+				}
 			} else {
 				self.log.V(1).Infof("[t]auth error %s = %s\n", clientId, err)
 			}

--- a/transport.go
+++ b/transport.go
@@ -397,6 +397,14 @@ func isBetterMode(current TransportMode, other TransportMode) bool {
 var lastAuthErrLogNano atomic.Int64
 var suppressedAuthErrCount atomic.Int64
 
+// lastWriteErrLogNano and suppressedWriteErrCount rate-limit [ts] write-error
+// log lines. A socket that is broken but still open keeps accepting writes that
+// immediately fail, so the writer goroutine retries in a tight loop and every
+// failed write logs a line. During an outage this floods the log just like the
+// auth path, so the same once-per-minute throttle is applied here.
+var lastWriteErrLogNano atomic.Int64
+var suppressedWriteErrCount atomic.Int64
+
 // shouldLogAuthErr returns (true, suppressedCount) if a log line should be emitted,
 // resetting the suppressed counter. Returns (false, 0) if the error is suppressed.
 func shouldLogAuthErr() (bool, int64) {
@@ -411,6 +419,25 @@ func shouldLogAuthErr() (bool, int64) {
 		return false, 0
 	}
 	suppressed := suppressedAuthErrCount.Swap(0)
+	return true, suppressed
+}
+
+// shouldLogWriteErr returns (true, suppressedCount) if a [ts] write-error line
+// should be emitted, resetting the suppressed counter. Returns (false, 0) if
+// suppressed. A broken-but-open socket retries writes in a tight loop; this
+// throttles that flood to one line per minute with a suppressed count.
+func shouldLogWriteErr() (bool, int64) {
+	now := time.Now().UnixNano()
+	last := lastWriteErrLogNano.Load()
+	if now-last < int64(time.Minute) {
+		suppressedWriteErrCount.Add(1)
+		return false, 0
+	}
+	if !lastWriteErrLogNano.CompareAndSwap(last, now) {
+		suppressedWriteErrCount.Add(1)
+		return false, 0
+	}
+	suppressed := suppressedWriteErrCount.Swap(0)
 	return true, suppressed
 }
 
@@ -682,7 +709,13 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 					MessagePoolReturn(message)
 					if err != nil {
 						// note that for websocket a dealine timeout cannot be recovered
-						self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+						if ok, suppressed := shouldLogWriteErr(); ok {
+							if suppressed > 0 {
+								self.log.Infof("[ts]%s-> error = %s (%d suppressed)\n", clientId, err, suppressed)
+							} else {
+								self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+							}
+						}
 						return err
 					}
 					self.log.V(2).Infof("[ts]%s->\n", clientId)


### PR DESCRIPTION
## Problem

During platform outages or degraded connectivity, two log lines flood terminal output at high volume, making it impossible to read logs or assess provider health:

\`\`\`
[t]auth error <uuid> = Timeout.          # one per transport, every ~5s
[contract]oob err = Timeout.; backing off create contract OOB requests for 1m0s   # one per ContractManager instance
\`\`\`

With 1000 proxies running, each proxy spawns its own \`PlatformTransport\` and its own \`ContractManager\`. Under a platform outage all 1000 can log simultaneously and continuously.

## Root cause

Both error paths had rate limiters scoped to the wrong level:

- \`[t]auth error\` — rate limiter was added per \`PlatformTransport\` instance. 1000 transports = 1000 independent limiters, each fires freely.
- \`[contract]oob err\` — \`markCreateContractOobError()\` used a per-\`ContractManager\` mutex. 1000 proxies = 1000 \`ContractManager\` instances (one created per \`provideWithProxy\` call), each fires independently.

The fix in both cases: **package-level \`atomic.Int64\`** shared across all instances, so the entire process emits at most one log line per minute regardless of how many proxies are running.

## Changes

**\`transport.go\`**
- Added \`lastAuthErrLogNano atomic.Int64\` and \`suppressedAuthErrCount atomic.Int64\` at package level
- \`shouldLogAuthErr()\` — CAS-based rate limiter, max one emit per minute globally across all \`PlatformTransport\` instances
- Suppressed count is reported on the next emitted line: \`[t]auth error <id> = Timeout. (32 suppressed)\`
- Errors that are suppressed are still logged at \`glog.V(1)\` for operators running with \`-v\`

**\`transfer_contract_manager.go\`**
- Added \`lastOobErrLogNano atomic.Int64\` and \`suppressedOobErrCount atomic.Int64\` at package level
- \`shouldLogOobErr()\` — same CAS pattern
- \`markCreateContractOobError()\` changed to void — still sets per-instance \`createContractOobErrorBackoffUntil\` to gate future contract creation attempts, but logging is now handled separately via the global limiter
- Suppressed count reported on next emit: \`[contract]oob err = Timeout.; backing off ... (34 suppressed)\`

## Stress test results

Tested on a live Detroit provider running 1000 proxies using \`tc netem\` applied via \`nsenter\` into the container network namespace. Five stages run across two builds.

### Stages 1–2 — \`netem delay 2000ms loss 50%\` (8 minutes each)

| Metric | Result |
|---|---|
| \`[t]auth error\` lines | **9** — exactly 1 per minute |
| \`[contract]oob err\` lines | **0** |
| Peak suppressed count | **3,964** |

Auth fix and OOB fix both verified. Suppressed counts climbed from 52 → 925 → 3,030 → ~3,960 as all 1000 proxies cascaded into timeout simultaneously.

### Stages 3–5 — \`netem loss 95% / 99% / 100%\` (10 minutes each)

| Metric | Result |
|---|---|
| \`[t]auth error\` lines | 1 per minute — fix held at all loss levels |
| \`[contract]oob err\` lines | 0–1 per stage, suppressed count reported correctly |
| Peak suppressed count | **3,980** |
| New pattern observed | \`[r]drop = Timeout.\` floods under 95%+ loss |

### Organic validation

Under real peak load (no netem), observed: \`[t]auth error ... (101 suppressed)\` and \`[t]auth error ... (3,952 suppressed)\` — single log lines absorbing thousands of simultaneous transport failures.

## Expected behavior after fix

| Log line | Before | After |
|---|---|---|
| \`[t]auth error\` | Every ~5s per transport × N proxies | At most once per minute globally, suppressed count reported |
| \`[contract]oob err\` | Every timeout per ContractManager × N proxies | At most once per minute globally, suppressed count reported |