### PR TITLE
fix: forceAllowDirect(nil, true) collapses auto mode into fixed WindowTypeQuality

### DIFF
--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -767,8 +767,7 @@ func forceAllowDirect(performanceProfile *PerformanceProfile, allowDirect bool) 
 			return nil
 		}
 		return &PerformanceProfile{
-			WindowType:  WindowTypeQuality,
-			WindowSize:  DefaultWindowSizeSettings(),
+			WindowType:  WindowTypeAuto,
 			AllowDirect: true,
 		}
 	}

--- a/ip_remote_multi_client_window_type_test.go
+++ b/ip_remote_multi_client_window_type_test.go
@@ -159,3 +159,30 @@ func TestMultiClientNetworkAllowDirectAuto(t *testing.T) {
 	AssertEqual(t, true, pp.AllowDirect)
 	AssertEqual(t, WindowTypeAuto, pp.WindowType)
 }
+
+// TestMultiClientNetworkAllowDirectNilProfileStaysAuto verifies that forcing
+// AllowDirect on with no profile set at all (DefaultPerformanceProfile nil)
+// fabricates an auto profile, not a fixed WindowTypeQuality one — forcing
+// direct mode must not pin the window as a side effect.
+func TestMultiClientNetworkAllowDirectNilProfileStaysAuto(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	settings := DefaultMultiClientSettings()
+	multiClient := NewRemoteUserNatMultiClient(
+		ctx,
+		&testingEmptyMultiClientGenerator{},
+		func(source TransferPath, provideMode protocol.ProvideMode, ipPath *IpPath, packet []byte) {
+		},
+		protocol.ProvideMode_Network,
+		settings,
+	)
+	defer multiClient.Close()
+
+	pp := multiClient.config.Load().performanceProfile
+	AssertEqual(t, true, pp != nil)
+	AssertEqual(t, true, pp.AllowDirect)
+	AssertEqual(t, WindowTypeAuto, pp.WindowType)
+	_, _, ok := pp.FixedWindow()
+	AssertEqual(t, false, ok)
+}


### PR DESCRIPTION
### Summary
`forceAllowDirect` fabricates a fallback `PerformanceProfile` when forcing `AllowDirect` on with no profile set. That fallback pins `WindowType: WindowTypeQuality` with a concrete `WindowSize`, rather than staying in "auto" (`WindowTypeAuto`). Per `WindowTypeAuto`'s own doc comment, a nil/unset profile is documented to mean auto load-balancing across Quality and Speed — this fallback silently breaks that guarantee as a side effect of merely toggling `AllowDirect`.

### Repro path
Reachable whenever `overrideAllowDirect`/`SetPerformanceProfile` is called with a `nil` profile while either `provideMode == protocol.ProvideMode_Network` (trusted same-network force) or `settings.OverrideAllowDirect` is explicitly `true` — e.g. a default-settings client in Network provide mode with no custom profile gets silently pinned to a single fixed window instead of auto-balancing.

### History
Written in `491578ce` ("perf improvements", 2026-07-19) as `withNetworkAllowDirect`, when `WindowType` only had `Quality`/`Speed` — defaulting to Quality wasn't wrong yet. `a2b144c` ("fixes", 2026-07-22, the commit this fix follows) introduced `WindowTypeAuto` and renamed the function to `forceAllowDirect`, but carried this fallback over unchanged, leaving it stale.

### Fix
```diff
 return &PerformanceProfile{
-    WindowType:  WindowTypeQuality,
-    WindowSize:  DefaultWindowSizeSettings(),
+    WindowType:  WindowTypeAuto,
     AllowDirect: true,
 }
```
`WindowSize` is dropped too since `FixedWindow()` ignores it under `WindowTypeAuto`.

### Testing
Adds `TestMultiClientNetworkAllowDirectNilProfileStaysAuto`, which fails against the current code (asserts `WindowTypeAuto` where it currently gets `WindowTypeQuality`) and passes with the fix. `go build ./...` and `go vet ./...` clean.