### PR TITLE
fix: stop removing providers that are still acknowledging traffic

### DIFF
--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -143,6 +143,7 @@ func DefaultMultiClientSettings() *MultiClientSettings {
 		// a lower ack timeout helps cycle through bad providers faster
 		AckTimeout:                                30 * time.Second,
 		BlackholeTimeout:                          5 * time.Second,
+		BlackholeReceiveTimeout:                   20 * time.Second,
 		BlackholeConnectTimeout:                   30 * time.Second,
 		WindowResizeTimeout:                       15 * time.Second,
 		StatsWindowGraceperiod:                    30 * time.Second,
@@ -225,15 +226,28 @@ type MultiClientSettings struct {
 	// ClientWriteTimeout time.Duration
 	// SendTimeout time.Duration
 	// WriteTimeout time.Duration
-	SendRetryTimeout                          time.Duration
-	PingWriteTimeout                          time.Duration
-	CPingWriteTimeout                         time.Duration
-	CPingMaxByteCountPerSecond                ByteCount
-	PingTimeout                               time.Duration
-	CPingTimeout                              time.Duration
-	CPingRestTimeout                          time.Duration
-	AckTimeout                                time.Duration
-	BlackholeTimeout                          time.Duration
+	SendRetryTimeout           time.Duration
+	PingWriteTimeout           time.Duration
+	CPingWriteTimeout          time.Duration
+	CPingMaxByteCountPerSecond ByteCount
+	PingTimeout                time.Duration
+	CPingTimeout               time.Duration
+	CPingRestTimeout           time.Duration
+	AckTimeout                 time.Duration
+	BlackholeTimeout           time.Duration
+	// BlackholeReceiveTimeout bounds the weaker of the two blackhole signals:
+	// the provider is acknowledging our sends, so it is demonstrably alive,
+	// but nothing has come back from the destination. That is ambiguous -- a
+	// flow waiting on a slow origin looks identical -- and removing an exit is
+	// destructive, killing every flow pinned to it rather than just the quiet
+	// one. So it gets a longer bar than BlackholeTimeout, which covers the
+	// unambiguous case of a provider that has stopped acknowledging anything.
+	//
+	// Bounded above by roughly StatsWindowDuration + StatsWindowBucketDuration:
+	// the age this compares against comes from surviving stat buckets, and
+	// coalesceEventBuckets drops buckets older than StatsWindowDuration. Past
+	// that ceiling it never fires, with no error and no log. 0 disables it.
+	BlackholeReceiveTimeout                   time.Duration
 	BlackholeConnectTimeout                   time.Duration
 	WindowResizeTimeout                       time.Duration
 	StatsWindowGraceperiod                    time.Duration
@@ -3833,11 +3847,20 @@ func (self *multiClientChannel) detectBlackhole() {
 		} else {
 			blackhole := func() bool {
 				now := time.Now()
-				if !windowStats.firstSendNackTime.IsZero() && self.settings.BlackholeTimeout-now.Sub(windowStats.firstSendNackTime) <= 0 {
-					if windowStats.sendAckCount <= 0 {
+				// two signals of very different strength, so they get
+				// different bars. see BlackholeReceiveTimeout
+				if !windowStats.firstSendNackTime.IsZero() {
+					sendNackAge := now.Sub(windowStats.firstSendNackTime)
+
+					// acknowledges nothing: the provider is not there
+					if self.settings.BlackholeTimeout <= sendNackAge && windowStats.sendAckCount <= 0 {
 						return true
 					}
-					if windowStats.receiveAckCount <= 0 {
+
+					// acknowledges our sends, but nothing back from the
+					// destination
+					receiveTimeout := self.settings.BlackholeReceiveTimeout
+					if 0 < receiveTimeout && receiveTimeout <= sendNackAge && windowStats.receiveAckCount <= 0 {
 						return true
 					}
 				}


### PR DESCRIPTION
`detectBlackhole` has two kill conditions sharing one 5s `BlackholeTimeout`:

```go
if windowStats.sendAckCount <= 0    { return true }   // acknowledges nothing
if windowStats.receiveAckCount <= 0 { return true }   // acks us, no destination data
```

## Evidence

A 20-minute Android capture against real providers, under load (scrolling a media-heavy feed):

| | |
|---|---|
| Removals | 45 — **44 `Blackhole`**, 1 `Done` |
| Median gap between removals | **18.5s** |
| Unique client ids | **45, zero repeats** |
| `sendAckCount` at removal | min **2**, median **10**, max **602** |
| `sendAckByteCount` | min 120B, median 8043B, max 222KB |

The numbers in `Blackhole (N XB)` are `sendAckCount` / `sendAckByteCount`. **Not one removal had `sendAckCount == 0`**, so the first condition never fired — every removal came from a provider being *quiet*, not absent. And a provider that has acknowledged 602 sends is demonstrably alive: the ack is written by the exit's own `ReceiveSequence`, not by an intermediary.

45 distinct providers each failing exactly once, never recurring, is also more consistent with an over-eager detector than with 45 independently broken exits.

## Change

The two signals differ in strength and no longer share a bound:

- **`BlackholeTimeout` (5s, unchanged)** — acknowledges nothing. Unambiguous.
- **`BlackholeReceiveTimeout` (20s, new)** — acknowledges our sends but returns no destination data. Ambiguous: a flow waiting on a slow origin looks identical. And since providers are split-TCP, removing an exit destroys *every* flow pinned to it, not just the quiet one — a destructive action that shouldn't be taken on 120 bytes of evidence.

`0` disables the weaker check, leaving only the unambiguous one.

## Two things worth a reviewer's attention

**The bound has a hard ceiling of about `StatsWindowDuration + StatsWindowBucketDuration`.** `firstSendNackTime` is derived from surviving stat buckets, and `coalesceEventBuckets` drops buckets older than `StatsWindowDuration`, so the age can never exceed ~31s at current constants. Above that the setting silently never fires — no error, no log. 20s leaves headroom, but if `StatsWindowDuration` is ever reduced this check disables itself quietly. Might be worth validating at construction.

**There is an existing, partly overlapping removal path.** A channel with acked sends and zero received bytes is already `unhealthy`, warned at `StatsWindowWarnUnhealthyDuration` (5s, which already stops new flows choosing it) and removed by the resize pass once `unhealthyDuration` passes `StatsWindowMaxUnhealthyDuration` (15s). That's reassuring for safety — a genuinely broken-egress provider doesn't linger for 20s — but it does mean the receive branch may now rarely win the race. If it turns out never to fire in practice, deleting it outright would be a reasonable outcome and I'd have no objection.

I don't have a controlled A/B on this yet; the evidence above is observational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
