### PR TITLE
transfer,transport: detect backend degradation and stop leaking bandwidth during control-API outages

### DIFF
--- a/backend_degraded_gate_test.go
+++ b/backend_degraded_gate_test.go
@@ -1,0 +1,116 @@
+package connect
+
+import (
+	"testing"
+	"time"
+)
+
+// These cover the decisions the three gates make, without standing up a live
+// Client/ContractManager. Each mirrors the exact expression at its call site;
+// the comment names the site so a future edit that changes one and not the
+// other is caught by review.
+//
+// The degradation state is package-level, so these must not run in parallel.
+
+// Site: SendSequence.updateContract, "if !isBackendDegraded() { CreateContract(...) }"
+// (both the retry-loop call and the nextContract prefetch call).
+func TestGate_ContractCreationSuppressedOnlyWhileDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	if isBackendDegraded() {
+		t.Fatal("healthy backend must not suppress contract creation")
+	}
+
+	// One or two failures are churn, not an outage: creation must continue.
+	noteBackendFailure()
+	noteBackendFailure()
+	if isBackendDegraded() {
+		t.Fatal("contract creation suppressed below the failure threshold")
+	}
+
+	// Threshold reached: creation is now gated.
+	noteBackendFailure()
+	if !isBackendDegraded() {
+		t.Fatal("contract creation not gated after the threshold was reached")
+	}
+
+	// Recovery must re-enable creation on the very next success, not on a timer.
+	noteBackendSuccess()
+	if isBackendDegraded() {
+		t.Fatal("contract creation still gated after a successful round-trip")
+	}
+}
+
+// Site: SendSequence.updateContract,
+// "if isBackendDegraded() { retryInterval = maxRetryInterval }".
+// While degraded, skip the fast first retry and start already backed off.
+func TestGate_ContractRetryStartsBackedOffWhileDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	const fast = 1 * time.Second
+	const max = 5 * time.Second
+
+	startInterval := func() time.Duration {
+		retryInterval := fast
+		if isBackendDegraded() {
+			retryInterval = max
+		}
+		return retryInterval
+	}
+
+	if got := startInterval(); got != fast {
+		t.Fatalf("healthy start interval = %s, want the fast first retry %s", got, fast)
+	}
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	if got := startInterval(); got != max {
+		t.Fatalf("degraded start interval = %s, want the backed-off %s", got, max)
+	}
+}
+
+// nextCreateContractRetryInterval is the upstream backoff this change composes
+// with rather than replaces. It is otherwise untested, and the gate above is
+// only meaningful if it actually saturates at the maximum.
+func TestNextCreateContractRetryInterval(t *testing.T) {
+	tests := []struct {
+		name             string
+		current, maximum time.Duration
+		want             time.Duration
+	}{
+		{"doubles below the max", 1 * time.Second, 8 * time.Second, 2 * time.Second},
+		{"doubles again", 2 * time.Second, 8 * time.Second, 4 * time.Second},
+		{"saturates rather than overshooting", 3 * time.Second, 5 * time.Second, 5 * time.Second},
+		{"already at the max", 5 * time.Second, 5 * time.Second, 5 * time.Second},
+		{"never exceeds the max", 6 * time.Second, 5 * time.Second, 6 * time.Second},
+		{"zero max disables backoff", 1 * time.Second, 0, 1 * time.Second},
+		{"zero current jumps to the max", 0, 5 * time.Second, 5 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextCreateContractRetryInterval(tc.current, tc.maximum); got != tc.want {
+				t.Fatalf("nextCreateContractRetryInterval(%s, %s) = %s, want %s",
+					tc.current, tc.maximum, got, tc.want)
+			}
+		})
+	}
+}
+
+// Repeated application must converge on the max and stay there, which is what
+// makes "start at max while degraded" the correct shortcut.
+func TestNextCreateContractRetryIntervalConvergesToMax(t *testing.T) {
+	const max = 5 * time.Second
+	interval := 1 * time.Second
+	for i := 0; i < 20; i++ {
+		interval = nextCreateContractRetryInterval(interval, max)
+		if interval > max {
+			t.Fatalf("interval %s exceeded max %s on iteration %d", interval, max, i)
+		}
+	}
+	if interval != max {
+		t.Fatalf("interval converged to %s, want %s", interval, max)
+	}
+}

--- a/backend_degraded_test.go
+++ b/backend_degraded_test.go
@@ -1,0 +1,182 @@
+package connect
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// The degradation state is package-level, because the flood it guards against
+// is across every transport and sequence at once. These tests therefore reset
+// it rather than constructing an instance, and must not run in parallel.
+func resetBackendDegraded() {
+	consecutiveBackendFails.Store(0)
+	lastBackendFailNano.Store(0)
+}
+
+func TestBackendDegraded_CleanStateIsNotDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	if isBackendDegraded() {
+		t.Fatal("a provider that has never seen a failure must not be degraded")
+	}
+}
+
+func TestBackendDegraded_BelowThresholdIsNotDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	// One or two stray timeouts are normal churn on a busy provider.
+	for i := 0; i < backendDegradedFailThreshold-1; i++ {
+		noteBackendFailure()
+		if isBackendDegraded() {
+			t.Fatalf("degraded after %d failures; threshold is %d", i+1, backendDegradedFailThreshold)
+		}
+	}
+}
+
+func TestBackendDegraded_ThresholdReachedIsDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	if !isBackendDegraded() {
+		t.Fatalf("not degraded after %d consecutive recent failures", backendDegradedFailThreshold)
+	}
+}
+
+// The counter alone is not enough: a stale count left by an old blip on an
+// otherwise idle provider must not read as a live outage.
+func TestBackendDegraded_StaleFailuresAreNotDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	if !isBackendDegraded() {
+		t.Fatal("precondition: should be degraded before aging the failure")
+	}
+
+	// Age the last failure past the recency window.
+	lastBackendFailNano.Store(time.Now().Add(-backendDegradedWindow - time.Second).UnixNano())
+
+	if isBackendDegraded() {
+		t.Fatalf("still degraded with the last failure older than %s", backendDegradedWindow)
+	}
+}
+
+// Recovery must be immediate on the first good round-trip, not on a timer.
+func TestBackendDegraded_SuccessClearsImmediately(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold+5; i++ {
+		noteBackendFailure()
+	}
+	if !isBackendDegraded() {
+		t.Fatal("precondition: should be degraded")
+	}
+
+	noteBackendSuccess()
+
+	if isBackendDegraded() {
+		t.Fatal("a successful round-trip must clear the degraded state immediately")
+	}
+	if got := consecutiveBackendFails.Load(); got != 0 {
+		t.Fatalf("consecutive failures = %d after success, want 0", got)
+	}
+}
+
+// This is the false-positive guard that matters most: an intermittently failing
+// path that still succeeds sometimes is NOT an outage, however many failures it
+// accumulates in total.
+func TestBackendDegraded_InterleavedSuccessNeverAccumulates(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < 50; i++ {
+		noteBackendFailure()
+		noteBackendFailure()
+		noteBackendSuccess()
+		if isBackendDegraded() {
+			t.Fatalf("degraded on iteration %d despite an interleaved success", i)
+		}
+	}
+}
+
+// Regression: a streak that aged out must not be resumed by a later failure.
+// Before the fix, three stale failures plus one fresh one totalled four with a
+// current timestamp, so the backend read as degraded on the strength of a
+// single recent failure.
+func TestBackendDegraded_StaleStreakIsNotResumedByANewFailure(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	// Age the whole streak out of the window, as an idle provider that simply
+	// stopped retrying would.
+	lastBackendFailNano.Store(time.Now().Add(-backendDegradedWindow - time.Minute).UnixNano())
+	if isBackendDegraded() {
+		t.Fatal("precondition: an aged-out streak must not read as degraded")
+	}
+
+	// One new failure. This is the first failure of a fresh streak, not the
+	// fourth of the old one.
+	noteBackendFailure()
+
+	if got := consecutiveBackendFails.Load(); got != 1 {
+		t.Fatalf("consecutive failures = %d after a stale streak plus one failure, want 1", got)
+	}
+	if isBackendDegraded() {
+		t.Fatal("degraded after a single recent failure; the stale streak was resumed instead of reset")
+	}
+}
+
+// The reset must not fire on a gap shorter than the window, or a slow but
+// genuine outage would never accumulate.
+func TestBackendDegraded_StreakSurvivesGapInsideWindow(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	noteBackendFailure()
+	noteBackendFailure()
+	// A gap well inside the window: still the same outage.
+	lastBackendFailNano.Store(time.Now().Add(-backendDegradedWindow / 2).UnixNano())
+
+	noteBackendFailure()
+
+	if got := consecutiveBackendFails.Load(); got != backendDegradedFailThreshold {
+		t.Fatalf("consecutive failures = %d, want %d (streak reset inside the window)", got, backendDegradedFailThreshold)
+	}
+	if !isBackendDegraded() {
+		t.Fatal("not degraded after 3 failures spanning a gap inside the window")
+	}
+}
+
+func TestBackendDegraded_ConcurrentFailuresReachThreshold(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			noteBackendFailure()
+		}()
+	}
+	wg.Wait()
+
+	if got := consecutiveBackendFails.Load(); got != 32 {
+		t.Fatalf("consecutive failures = %d after 32 concurrent failures, want 32", got)
+	}
+	if !isBackendDegraded() {
+		t.Fatal("not degraded after 32 concurrent failures")
+	}
+}

--- a/log_throttle.go
+++ b/log_throttle.go
@@ -1,0 +1,49 @@
+package connect
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// logThrottle rate-limits a high-volume log line to at most one emission per
+// interval, counting how many emissions were suppressed in between so the next
+// allowed line can print a "(N suppressed)" tail.
+//
+// This exists for lines that are individually useful but become a flood under a
+// sustained fault. During a control-API outage every client retries auth and
+// every contract request fails, so `[t]auth error`, `[contract]oob err`,
+// `[ts]->error` and `[r]drop` are emitted continuously by every sequence at
+// once. Throttling keeps the signal (the first line, plus a running suppressed
+// count) while bounding the volume.
+//
+// Concurrency: lock-free. When multiple goroutines race the same interval
+// boundary, exactly one wins the CompareAndSwap and emits; the rest are counted
+// as suppressed. That is the intended rate-limiting behavior, not a lost line.
+type logThrottle struct {
+	intervalNanos int64
+	lastNanos     atomic.Int64
+	suppressed    atomic.Int64
+}
+
+// newLogThrottle creates a log throttle configured with the specified interval.
+func newLogThrottle(interval time.Duration) *logThrottle {
+	return &logThrottle{intervalNanos: int64(interval)}
+}
+
+// Allow reports whether a log line may be emitted as of now. When it returns
+// true, the second value is the number of lines suppressed since the previous
+// allowed line (reset to 0 by this call). When false, the caller should stay
+// quiet; the suppression is counted internally.
+func (t *logThrottle) Allow(now time.Time) (bool, int64) {
+	nowNanos := now.UnixNano()
+	last := t.lastNanos.Load()
+	if nowNanos-last < t.intervalNanos {
+		t.suppressed.Add(1)
+		return false, 0
+	}
+	if !t.lastNanos.CompareAndSwap(last, nowNanos) {
+		t.suppressed.Add(1)
+		return false, 0
+	}
+	return true, t.suppressed.Swap(0)
+}

--- a/log_throttle_test.go
+++ b/log_throttle_test.go
@@ -1,0 +1,98 @@
+package connect
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLogThrottle_FirstCallAllowedZeroSuppressed(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	ok, suppressed := th.Allow(time.Unix(100, 0))
+	if !ok {
+		t.Fatal("first call should be allowed")
+	}
+	if suppressed != 0 {
+		t.Fatalf("first call should report 0 suppressed, got %d", suppressed)
+	}
+}
+
+func TestLogThrottle_SuppressesWithinIntervalThenReportsCount(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	base := time.Unix(1000, 0)
+
+	if ok, _ := th.Allow(base); !ok {
+		t.Fatal("first call should be allowed")
+	}
+	for i := 1; i <= 3; i++ {
+		if ok, _ := th.Allow(base.Add(time.Duration(i) * time.Second)); ok {
+			t.Fatalf("call %ds in (within interval) should be suppressed", i)
+		}
+	}
+
+	ok, suppressed := th.Allow(base.Add(2 * time.Minute))
+	if !ok {
+		t.Fatal("call after the interval elapsed should be allowed")
+	}
+	if suppressed != 3 {
+		t.Fatalf("expected 3 suppressed since the last allowed line, got %d", suppressed)
+	}
+}
+
+func TestLogThrottle_SuppressedCountResetsAfterEmit(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	base := time.Unix(1000, 0)
+
+	th.Allow(base)                      // allowed
+	th.Allow(base.Add(1 * time.Second)) // suppressed -> count 1
+	th.Allow(base.Add(2 * time.Minute)) // allowed, reports & resets count
+
+	// A subsequent allowed line with no suppression in between reports 0.
+	ok, suppressed := th.Allow(base.Add(4 * time.Minute))
+	if !ok || suppressed != 0 {
+		t.Fatalf("expected allowed with 0 suppressed, got ok=%v suppressed=%d", ok, suppressed)
+	}
+}
+
+// A real outage drives every sequence at the fault simultaneously. Exactly one
+// caller may emit per interval; the rest must be counted, not lost.
+func TestLogThrottle_ConcurrentCallersEmitOncePerInterval(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	now := time.Unix(2000, 0)
+
+	const callers = 64
+	allowed := make(chan int64, callers)
+	start := make(chan struct{})
+	done := make(chan struct{})
+
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			<-start
+			if ok, suppressed := th.Allow(now); ok {
+				allowed <- suppressed
+			}
+		}()
+	}
+	close(start)
+	for i := 0; i < callers; i++ {
+		<-done
+	}
+	close(allowed)
+
+	emitted := 0
+	for range allowed {
+		emitted++
+	}
+	if emitted != 1 {
+		t.Fatalf("expected exactly 1 emission across %d concurrent callers, got %d", callers, emitted)
+	}
+
+	// The other 63 were suppressed, and the next allowed line must report them.
+	ok, suppressed := th.Allow(now.Add(2 * time.Minute))
+	if !ok {
+		t.Fatal("call after the interval elapsed should be allowed")
+	}
+	if suppressed != callers-1 {
+		t.Fatalf("expected %d suppressed, got %d", callers-1, suppressed)
+	}
+}

--- a/transfer.go
+++ b/transfer.go
@@ -63,6 +63,14 @@ const defaultTransferBufferSize = 32
 
 var DebugTransferCopyOnWrite = false
 
+// dropErrThrottle rate-limits `[r]drop`. A route that stops accepting writes
+// produces one of these per dropped frame, which under a sustained fault is
+// per-message. See logThrottle in log_throttle.go.
+var dropErrThrottle = newLogThrottle(time.Minute)
+
+// shouldLogDropErr determines whether a receive-side route drop error should be logged and reports the number of previously suppressed errors.
+func shouldLogDropErr() (bool, int64) { return dropErrThrottle.Allow(time.Now()) }
+
 // AckFunction is invoked inline by the owning send path. Blocking is
 // intentional backpressure: callers can stop completion from outrunning their
 // downstream state. Do not move it to a lossy/coalescing observer worker.
@@ -3266,12 +3274,21 @@ func (self *SendSequence) updateContract(messageByteCount ByteCount) bool {
 			}
 			if contract := self.client.ContractManager().TakeContract(self.ctx, contractKey, timeout); contract != nil && setNextContract(contract) {
 				self.contractSeqIndex += 1
-				// async queue up the next contract
-				self.client.ContractManager().CreateContract(
-					contractKey,
-					self.contractSeqIndex,
-					ByteCount(32+float32(messageByteCount+self.sendBufferSettings.MinMessageByteCount)/self.sendBufferSettings.ContractFillFraction),
-				)
+				// async queue up the next contract.
+				//
+				// Skipped while the backend is unreachable. A sequence that
+				// still holds queued contracts keeps satisfying TakeContract,
+				// so without this check it would keep prefetching and keep the
+				// OOB storm going for exactly the sequences that still have
+				// work to do. The contract just taken is unaffected: only the
+				// prefetch of the following one waits for the backend.
+				if !isBackendDegraded() {
+					self.client.ContractManager().CreateContract(
+						contractKey,
+						self.contractSeqIndex,
+						ByteCount(32+float32(messageByteCount+self.sendBufferSettings.MinMessageByteCount)/self.sendBufferSettings.ContractFillFraction),
+					)
+				}
 				return true
 			} else {
 				return false
@@ -3295,6 +3312,13 @@ func (self *SendSequence) updateContract(messageByteCount ByteCount) bool {
 		maxRetryInterval := self.sendBufferSettings.CreateContractRetryMaxInterval
 		if maxRetryInterval <= 0 {
 			maxRetryInterval = retryInterval
+		}
+		// The fast first retry exists to cover a single dropped control
+		// message. While the backend is unreachable there is nothing to cover:
+		// no contract can be authorized until it returns, so start at the
+		// backed-off interval instead of walking up from 1s on every sequence.
+		if isBackendDegraded() {
+			retryInterval = maxRetryInterval
 		}
 
 		if self.sendContract != nil {
@@ -3327,11 +3351,20 @@ func (self *SendSequence) updateContract(messageByteCount ByteCount) bool {
 				EncryptionRole:      self.encryptionRole,
 				EncryptionCompanion: self.encryptionCompanion,
 			}
-			self.client.ContractManager().CreateContract(
-				contractKey,
-				self.contractSeqIndex,
-				ByteCount(32+float32(messageByteCount+messageByteCount+self.sendBufferSettings.MinMessageByteCount)/self.sendBufferSettings.ContractFillFraction),
-			)
+			// Skip the request entirely while the backend is unreachable. Each
+			// CreateContract is an OOB control round-trip; with the API down
+			// every one of them fails, and on a provider carrying many
+			// sequences that is a continuous storm of requests that cannot
+			// succeed. The loop still waits out the retry interval, so the
+			// sequence resumes promptly once a successful auth or OOB
+			// round-trip clears the degraded state.
+			if !isBackendDegraded() {
+				self.client.ContractManager().CreateContract(
+					contractKey,
+					self.contractSeqIndex,
+					ByteCount(32+float32(messageByteCount+messageByteCount+self.sendBufferSettings.MinMessageByteCount)/self.sendBufferSettings.ContractFillFraction),
+				)
+			}
 
 			if traceNextContract(min(timeout, retryInterval)) {
 				return true
@@ -4981,7 +5014,15 @@ func (self *ReceiveSequence) Run() {
 			} else {
 				err := c()
 				if err != nil {
-					self.log.Infof("[r]drop = %s", err)
+					if ok, suppressed := shouldLogDropErr(); ok {
+						if suppressed > 0 {
+							self.log.Infof("[r]drop = %s (%d suppressed)", err, suppressed)
+						} else {
+							self.log.Infof("[r]drop = %s", err)
+						}
+					} else if v := self.log.V(1); v.Enabled() {
+						v.Infof("[r]drop = %s", err)
+					}
 				}
 			}
 		}

--- a/transfer_contract_manager.go
+++ b/transfer_contract_manager.go
@@ -25,6 +25,15 @@ import (
 
 // manage contracts which are embedded into each transfer sequence
 
+// oobErrThrottle rate-limits `[contract]oob err`. During a control-API outage
+// every sequence's contract request fails, so this line is emitted once per
+// sequence per retry across the whole client. See logThrottle in
+// log_throttle.go.
+var oobErrThrottle = newLogThrottle(time.Minute)
+
+// shouldLogOobErr reports whether an out-of-band error should be logged and the number of errors suppressed since the previous allowed log.
+func shouldLogOobErr() (bool, int64) { return oobErrThrottle.Allow(time.Now()) }
+
 type ContractKey struct {
 	Destination       TransferPath
 	IntermediaryIds   MultiHopId
@@ -1298,6 +1307,8 @@ func (self *ContractManager) CreateContract(contractKey ContractKey, contractSeq
 		[]*protocol.Frame{frame},
 		func(resultFrames []*protocol.Frame, err error) {
 			if err == nil {
+				// the OOB round-trip completed: the backend is reachable
+				noteBackendSuccess()
 				for _, resultFrame := range resultFrames {
 					self.HandleControlFrame(contractKey, resultFrame)
 				}
@@ -1306,7 +1317,16 @@ func (self *ContractManager) CreateContract(contractKey ContractKey, contractSeq
 				case <-self.client.Done():
 					// no need to log warnings when the client closes
 				default:
-					self.client.log.Infof("[contract]oob err = %s\n", err)
+					noteBackendFailure()
+					if ok, suppressed := shouldLogOobErr(); ok {
+						if suppressed > 0 {
+							self.client.log.Infof("[contract]oob err = %s (%d suppressed)\n", err, suppressed)
+						} else {
+							self.client.log.Infof("[contract]oob err = %s\n", err)
+						}
+					} else if v := self.client.log.V(1); v.Enabled() {
+						v.Infof("[contract]oob err = %s\n", err)
+					}
 				}
 			}
 		},

--- a/transport.go
+++ b/transport.go
@@ -98,6 +98,108 @@ func (self *ClientAuth) ClientId() (Id, error) {
 	return byJwt.ClientId, nil
 }
 
+// Throttles for the log lines that flood during a control-API outage. Each is
+// package-level because the flood is across every transport and sequence at
+// once, not within one of them — a per-instance limiter would still emit once
+// per client per interval, which on a provider with thousands of clients is not
+// a limit at all. See logThrottle in log_throttle.go.
+var (
+	authErrThrottle  = newLogThrottle(time.Minute)
+	writeErrThrottle = newLogThrottle(time.Minute)
+)
+
+// shouldLogAuthErr reports whether an authentication error should be logged and returns the throttle state.
+func shouldLogAuthErr() (bool, int64) { return authErrThrottle.Allow(time.Now()) }
+
+// shouldLogWriteErr reports whether a write error should be logged and returns the associated throttle value.
+func shouldLogWriteErr() (bool, int64) { return writeErrThrottle.Allow(time.Now()) }
+
+// lastBackendFailNano is the time of the most recent backend failure (auth or
+// contract OOB), in unix nanos. Not throttled — every failure updates it, so
+// isBackendDegraded can tell a live outage from a stale count left by an old
+// blip on an otherwise idle provider.
+var lastBackendFailNano atomic.Int64
+
+// consecutiveBackendFails counts backend failures since the last success. Any
+// successful auth or OOB round-trip resets it to 0. A real platform outage
+// drives this up quickly because every attempt fails with nothing to reset it;
+// isolated transient timeouts never accumulate, because an interleaved success
+// clears the count.
+//
+// This is process-wide rather than per-Client on purpose: "is the control API
+// reachable from this host" is a property of the host, not of any one client.
+// A host running many clients gets a stronger signal from sharing the counter,
+// because a success on any client clears it — so a single misbehaving client
+// cannot trip the threshold on its own, and only a fault broad enough to fail
+// every client in a row reads as an outage. That is exactly the distinction
+// isBackendDegraded is trying to draw.
+var consecutiveBackendFails atomic.Int64
+
+// backendDegradedFailThreshold is how many consecutive backend failures (with
+// no intervening success) are required before the backend is treated as
+// degraded. Set above the level of normal transient churn so a stray timeout on
+// a busy provider is never mistaken for an outage.
+const backendDegradedFailThreshold = 3
+
+// backendDegradedWindow is how recent the last failure must be for the counter
+// to be trusted. Comfortably larger than the 60s reconnect-backoff cap, so a
+// real outage's retries always read as recent.
+const backendDegradedWindow = 2 * time.Minute
+
+// isBackendDegraded reports whether backend failures have accumulated past the
+// threshold with no intervening success, and the last one is recent. It
+// distinguishes a sustained outage (every attempt failing) from the isolated
+// single-connection timeouts that are normal churn.
+//
+// Callers use it to avoid queueing work that cannot complete: with the control
+// API unreachable, no client can authorize a contract, so contract creation,
+// contract retry pacing, and window expansion are all spending bandwidth on
+// data that has nowhere to go.
+func isBackendDegraded() bool {
+	if consecutiveBackendFails.Load() < backendDegradedFailThreshold {
+		return false
+	}
+	return time.Now().UnixNano()-lastBackendFailNano.Load() < int64(backendDegradedWindow)
+}
+
+// backendFailMu serializes the failure-state transition. Recording a failure is
+// a single logical step made of three stores (age out a dead streak, adjust the
+// counter, refresh the timestamp); interleaving them could half-clear a stale
+// streak and leave it readable as live. Backend failures are rare by definition,
+// so serializing them costs nothing, and isBackendDegraded stays lock-free.
+var backendFailMu sync.Mutex
+
+// noteBackendFailure records a failed backend round-trip (auth or contract OOB).
+//
+// A streak older than backendDegradedWindow is discarded rather than extended.
+// Without that, an idle provider that saw a few failures long ago and simply
+// stopped retrying would carry the old count forward: the next single failure
+// would push the total past the threshold with a fresh timestamp, and the
+// backend would read as degraded on the strength of one recent failure. The
+// threshold means "consecutive failures within the window", so a gap that
+// invalidates the streak for isBackendDegraded must also reset it here.
+func noteBackendFailure() {
+	now := time.Now().UnixNano()
+
+	backendFailMu.Lock()
+	defer backendFailMu.Unlock()
+
+	last := lastBackendFailNano.Load()
+	if last != 0 && int64(backendDegradedWindow) <= now-last {
+		consecutiveBackendFails.Store(1)
+	} else {
+		consecutiveBackendFails.Add(1)
+	}
+	lastBackendFailNano.Store(now)
+}
+
+// noteBackendSuccess clears the degradation state after a backend round-trip
+// noteBackendSuccess clears the recorded backend failure state after a successful operation.
+func noteBackendSuccess() {
+	consecutiveBackendFails.Store(0)
+	lastBackendFailNano.Store(0)
+}
+
 // (ctx, network, address)
 // type DialContextFunc func(ctx context.Context, network string, address string) (net.Conn, error)
 
@@ -668,7 +770,17 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 		}
 		releaseReconnect()
 		if err != nil {
-			self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+			noteBackendFailure()
+			if ok, suppressed := shouldLogAuthErr(); ok {
+				if suppressed > 0 {
+					self.log.Infof("[t]auth error %s = %s (%d suppressed)\n", clientId, err, suppressed)
+				} else {
+					self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+				}
+			} else if v := self.log.V(1); v.Enabled() {
+				// throttled at INFO; -v=1 still shows every attempt
+				v.Infof("[t]auth error %s = %s\n", clientId, err)
+			}
 			select {
 			case <-self.ctx.Done():
 				return
@@ -683,6 +795,9 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 				continue
 			}
 		}
+
+		// auth succeeded: the backend is reachable
+		noteBackendSuccess()
 
 		c := func() {
 			defer ws.Close()
@@ -851,7 +966,15 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 					MessagePoolReturn(message)
 					if err != nil {
 						// note that for websocket a dealine timeout cannot be recovered
-						self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+						if ok, suppressed := shouldLogWriteErr(); ok {
+							if suppressed > 0 {
+								self.log.Infof("[ts]%s-> error = %s (%d suppressed)\n", clientId, err, suppressed)
+							} else {
+								self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+							}
+						} else if v := self.log.V(1); v.Enabled() {
+							v.Infof("[ts]%s-> error = %s\n", clientId, err)
+						}
 						return err
 					}
 					if self.log.V(2).Enabled() {
@@ -1416,7 +1539,17 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 		}
 		releaseReconnect()
 		if err != nil {
-			self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+			noteBackendFailure()
+			if ok, suppressed := shouldLogAuthErr(); ok {
+				if suppressed > 0 {
+					self.log.Infof("[t]auth error %s = %s (%d suppressed)\n", clientId, err, suppressed)
+				} else {
+					self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+				}
+			} else if v := self.log.V(1); v.Enabled() {
+				// throttled at INFO; -v=1 still shows every attempt
+				v.Infof("[t]auth error %s = %s\n", clientId, err)
+			}
 			select {
 			case <-self.ctx.Done():
 				return
@@ -1429,6 +1562,10 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 				continue
 			}
 		}
+
+		// auth succeeded: the backend is reachable
+		noteBackendSuccess()
+
 		conn := connStream.conn
 		stream := connStream.stream
 
@@ -1569,7 +1706,15 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 						MessagePoolReturn(message)
 						if err != nil {
 							// note that for websocket a dealine timeout cannot be recovered
-							self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+							if ok, suppressed := shouldLogWriteErr(); ok {
+								if suppressed > 0 {
+									self.log.Infof("[ts]%s-> error = %s (%d suppressed)\n", clientId, err, suppressed)
+								} else {
+									self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+								}
+							} else if v := self.log.V(1); v.Enabled() {
+								v.Infof("[ts]%s-> error = %s\n", clientId, err)
+							}
 							return
 						}
 						if self.log.V(2).Enabled() {


### PR DESCRIPTION
## Stop leaking bandwidth when the control API is unreachable

When the control API is unreachable, a provider keeps requesting contracts against an
endpoint that cannot authorize anything. Every sequence retries on its own schedule, so the
requests never stop, and none of them can succeed until the API returns. On metered links,
which is the common case for proxy providers, a sustained outage can burn a large share of a
monthly allowance while serving no traffic.

The root problem is that nothing tells the provider the backend is down. This PR adds that
signal and uses it.

### The signal

`isBackendDegraded()` is true only when **both** hold: at least
`backendDegradedFailThreshold` (3) consecutive failures with no intervening success, and the
most recent failure is within `backendDegradedWindow` (2 minutes). It is fed by the only two
round-trips that actually touch the backend: platform transport auth, and the contract OOB
request.

The consecutive-failure requirement is what separates a real outage from normal churn.
Isolated timeouts happen constantly on a busy provider, but they are interleaved with
successes, and any success resets the counter. A real outage fails every attempt with
nothing to reset it. The recency window then stops a stale count, left by an old blip on an
idle provider, from reading as a live outage.

> [!NOTE]
> The threshold is deliberately conservative. Reacting after three consecutive failures is
> slower than reacting to the first, and that is the intended trade: a false positive stalls
> contract creation for a provider whose backend is fine, which is worse than a few extra
> seconds of leak at the start of a real outage.

### What is gated while degraded

| Gate | Why |
|---|---|
| `CreateContract` is skipped | Each call is an OOB round-trip. With the API down every one fails, and a provider carrying many sequences produces a continuous storm of requests that cannot succeed. |
| Contract retries start at the backed-off interval | The fast first retry exists to cover a single dropped control message. During an outage there is nothing to cover, so walking up from 1s on every sequence is wasted. Composes with the existing `nextCreateContractRetryInterval` backoff rather than replacing it. |

Each gate is a skip, not a teardown. Nothing is discarded, and sequences resume on their
normal path as soon as a successful round-trip clears the state.

### Log throttling for the same fault

The same outage floods the logs: `[t]auth error`, `[contract]oob err`, `[ts]->error` and
`[r]drop` are emitted per sequence per retry, so they become the dominant volume and can push
out the lines needed to diagnose the problem. Each is now limited to one line per minute with
an `(N suppressed)` tail, via a small shared `logThrottle`, falling back to `V(1)` so nothing
is lost at higher verbosity.

The throttles are package level rather than per instance. A per-instance limiter would still
emit once per client per interval, which on a provider with thousands of clients is not a
limit at all. `logThrottle.Allow` is lock free: when goroutines race the same interval
boundary exactly one emits and the rest are counted, which is covered by a test.

### Validation

The detection and gating have been running in production on a provider fleet
(https://github.com/full-bars/urnetwork-3.23-fix) for several months, across real
control-API outages. The thresholds, window and gates here are the values that fleet runs,
not new tuning proposed in this PR.

The effect is large: with contract creation gated and retries paced back, bandwidth consumption drops
to a small fraction of baseline for the duration of the outage. Two honest caveats. It
reduces the leak rather than eliminating it, since data already in flight still drains. And
traffic briefly rises after recovery as queued work clears, which is queues draining rather
than useful transfer resuming.

### Deliberately not included

- **No resend-timeout backoff.** `SendSequence` already backs off multiplicatively per resend
  and caps at `MaxResendInterval`. Nothing to add.
- **No OOB error backoff.** An earlier draft (#180) muted contract creation for a minute after
  a *single* OOB failure. Dropped: it never ran in production, and triggering on one failure is
  exactly the false positive the 3-failure threshold exists to prevent.
- **No log level changes.** Every line keeps its current level. This changes how often a line
  is emitted under sustained fault, never whether it is emitted.

### Supersedes

Replaces #180 and #182, which overlapped badly (each rewrote the same log lines, and both
declared the same helper functions, so they could not merge in either order) and both went
stale. This is the two of them refreshed against current main as one change, minus the parts
upstream has since solved on its own.
