### PR TITLE
transfer,transport: detect backend degradation and stop leaking bandwidth during control-API outages

### DIFF
--- a/backend_degraded_contract_manager_test.go
+++ b/backend_degraded_contract_manager_test.go
@@ -1,0 +1,124 @@
+package connect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/urnetwork/connect/protocol"
+)
+
+// These exercise the actual call site in ContractManager.CreateContract (see
+// transfer_contract_manager.go) rather than the isolated gate expression
+// covered by backend_degraded_gate_test.go: a real OOB round-trip must drive
+// noteBackendFailure/noteBackendSuccess, not just a value that happens to be
+// wired up in a test double for some other assertion.
+//
+// The degradation state is package-level, so these must not run in parallel.
+
+// alwaysSuccessOob is a minimal OutOfBandControl that acks synchronously with
+// no error and no result frames, mirroring how testOobControl in
+// transfer_control_oob_test.go consumes and releases the input frames.
+type alwaysSuccessOob struct{}
+
+func (alwaysSuccessOob) SendControl(frames []*protocol.Frame, callback OobResultFunction) {
+	for _, frame := range frames {
+		MessagePoolReturn(frame.MessageBytes)
+	}
+	callback(nil, nil)
+}
+
+func newBackendDegradedContractManagerTestClient(t *testing.T, oob OutOfBandControl) *Client {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	client := NewClient(ctx, NewId(), oob, DefaultClientSettings())
+	t.Cleanup(func() {
+		client.Cancel()
+		cancel()
+	})
+	return client
+}
+
+// NoContractClientOob.SendControl fails synchronously ("Not supported."), so
+// CreateContract's failure branch — including noteBackendFailure — runs
+// inline, before CreateContract returns. That makes the threshold crossing
+// deterministic without needing to wait on a goroutine.
+func TestContractManagerCreateContract_OobFailureAccumulatesTowardDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	client := newBackendDegradedContractManagerTestClient(t, NewNoContractClientOob())
+	contractManager := client.ContractManager()
+	contractKey := ContractKey{Destination: DestinationId(NewId())}
+
+	if isBackendDegraded() {
+		t.Fatal("precondition: fresh client must not start degraded")
+	}
+
+	for i := 0; i < backendDegradedFailThreshold-1; i++ {
+		contractManager.CreateContract(contractKey, uint64(i), ByteCount(1024))
+	}
+	if isBackendDegraded() {
+		t.Fatalf("degraded before %d OOB failures were recorded", backendDegradedFailThreshold)
+	}
+
+	contractManager.CreateContract(contractKey, uint64(backendDegradedFailThreshold), ByteCount(1024))
+	if !isBackendDegraded() {
+		t.Fatalf("not degraded after %d consecutive OOB failures from CreateContract", backendDegradedFailThreshold)
+	}
+}
+
+// A successful CreateContract round-trip must clear degradation immediately,
+// the same as any other backend success — this is the recovery half of the
+// same call site.
+func TestContractManagerCreateContract_OobSuccessClearsDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	if !isBackendDegraded() {
+		t.Fatal("precondition: should be degraded before the successful round-trip")
+	}
+
+	client := newBackendDegradedContractManagerTestClient(t, alwaysSuccessOob{})
+	contractManager := client.ContractManager()
+	contractKey := ContractKey{Destination: DestinationId(NewId())}
+
+	contractManager.CreateContract(contractKey, 0, ByteCount(1024))
+
+	if isBackendDegraded() {
+		t.Fatal("a successful CreateContract OOB round-trip must clear the degraded state")
+	}
+	if got := consecutiveBackendFails.Load(); got != 0 {
+		t.Fatalf("consecutive failures = %d after a successful CreateContract, want 0", got)
+	}
+}
+
+// Regression guard on the client-shutdown carve-out immediately above the
+// failure branch: CreateContract does not call noteBackendFailure when the
+// error is due to the client already being done (see the `<-self.client.Done()`
+// case), since that is a local shutdown, not a backend signal.
+func TestContractManagerCreateContract_ClientDoneDoesNotNoteFailure(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := NewClient(ctx, NewId(), NewNoContractClientOob(), DefaultClientSettings())
+	contractKey := ContractKey{Destination: DestinationId(NewId())}
+
+	// close the client's lifecycle before the OOB failure is observed
+	client.Cancel()
+	cancel()
+	<-client.Done()
+
+	contractManager := client.ContractManager()
+	contractManager.CreateContract(contractKey, 0, ByteCount(1024))
+
+	if got := consecutiveBackendFails.Load(); got != 0 {
+		t.Fatalf("consecutive failures = %d after a post-shutdown CreateContract error, want 0 (shutdown is not a backend signal)", got)
+	}
+	if isBackendDegraded() {
+		t.Fatal("a post-shutdown CreateContract error must not read as backend degradation")
+	}
+}

--- a/backend_degraded_gate_test.go
+++ b/backend_degraded_gate_test.go
@@ -1,0 +1,116 @@
+package connect
+
+import (
+	"testing"
+	"time"
+)
+
+// These cover the decisions the three gates make, without standing up a live
+// Client/ContractManager. Each mirrors the exact expression at its call site;
+// the comment names the site so a future edit that changes one and not the
+// other is caught by review.
+//
+// The degradation state is package-level, so these must not run in parallel.
+
+// Site: SendSequence.updateContract, "if !isBackendDegraded() { CreateContract(...) }"
+// (both the retry-loop call and the nextContract prefetch call).
+func TestGate_ContractCreationSuppressedOnlyWhileDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	if isBackendDegraded() {
+		t.Fatal("healthy backend must not suppress contract creation")
+	}
+
+	// One or two failures are churn, not an outage: creation must continue.
+	noteBackendFailure()
+	noteBackendFailure()
+	if isBackendDegraded() {
+		t.Fatal("contract creation suppressed below the failure threshold")
+	}
+
+	// Threshold reached: creation is now gated.
+	noteBackendFailure()
+	if !isBackendDegraded() {
+		t.Fatal("contract creation not gated after the threshold was reached")
+	}
+
+	// Recovery must re-enable creation on the very next success, not on a timer.
+	noteBackendSuccess()
+	if isBackendDegraded() {
+		t.Fatal("contract creation still gated after a successful round-trip")
+	}
+}
+
+// Site: SendSequence.updateContract,
+// "if isBackendDegraded() { retryInterval = maxRetryInterval }".
+// While degraded, skip the fast first retry and start already backed off.
+func TestGate_ContractRetryStartsBackedOffWhileDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	const fast = 1 * time.Second
+	const max = 5 * time.Second
+
+	startInterval := func() time.Duration {
+		retryInterval := fast
+		if isBackendDegraded() {
+			retryInterval = max
+		}
+		return retryInterval
+	}
+
+	if got := startInterval(); got != fast {
+		t.Fatalf("healthy start interval = %s, want the fast first retry %s", got, fast)
+	}
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	if got := startInterval(); got != max {
+		t.Fatalf("degraded start interval = %s, want the backed-off %s", got, max)
+	}
+}
+
+// nextCreateContractRetryInterval is the upstream backoff this change composes
+// with rather than replaces. It is otherwise untested, and the gate above is
+// only meaningful if it actually saturates at the maximum.
+func TestNextCreateContractRetryInterval(t *testing.T) {
+	tests := []struct {
+		name             string
+		current, maximum time.Duration
+		want             time.Duration
+	}{
+		{"doubles below the max", 1 * time.Second, 8 * time.Second, 2 * time.Second},
+		{"doubles again", 2 * time.Second, 8 * time.Second, 4 * time.Second},
+		{"saturates rather than overshooting", 3 * time.Second, 5 * time.Second, 5 * time.Second},
+		{"already at the max", 5 * time.Second, 5 * time.Second, 5 * time.Second},
+		{"never exceeds the max", 6 * time.Second, 5 * time.Second, 6 * time.Second},
+		{"zero max disables backoff", 1 * time.Second, 0, 1 * time.Second},
+		{"zero current jumps to the max", 0, 5 * time.Second, 5 * time.Second},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextCreateContractRetryInterval(tc.current, tc.maximum); got != tc.want {
+				t.Fatalf("nextCreateContractRetryInterval(%s, %s) = %s, want %s",
+					tc.current, tc.maximum, got, tc.want)
+			}
+		})
+	}
+}
+
+// Repeated application must converge on the max and stay there, which is what
+// makes "start at max while degraded" the correct shortcut.
+func TestNextCreateContractRetryIntervalConvergesToMax(t *testing.T) {
+	const max = 5 * time.Second
+	interval := 1 * time.Second
+	for i := 0; i < 20; i++ {
+		interval = nextCreateContractRetryInterval(interval, max)
+		if interval > max {
+			t.Fatalf("interval %s exceeded max %s on iteration %d", interval, max, i)
+		}
+	}
+	if interval != max {
+		t.Fatalf("interval converged to %s, want %s", interval, max)
+	}
+}

--- a/backend_degraded_test.go
+++ b/backend_degraded_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -221,5 +222,37 @@ func TestBackendDegraded_ConcurrentFailuresReachThreshold(t *testing.T) {
 	}
 	if !isBackendDegraded() {
 		t.Fatal("not degraded after 32 concurrent failures")
+	}
+}
+
+// The auth sites must make the same local-teardown carve-out the contract OOB
+// path makes on client.Done: a canceled dial is this process shutting a
+// transport down, not the backend failing. Closing a multi-client window
+// cancels many transports at once, and without the guard that burst of
+// canceled dials trips the threshold with fresh timestamps -- so the NEXT
+// session starts gated. runH1/runH3 are connect loops that need a live server
+// to drive, so this pins the call-site shape the way the resize-pass anchors
+// do, for both transports at once.
+func TestAuthCancellationIsNotBackendFailure(t *testing.T) {
+	source, err := readSource("transport.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fn := range []string{
+		"func (self *PlatformTransport) runH1(",
+		"func (self *PlatformTransport) runH3(",
+	} {
+		body, ok := functionBody(source, fn)
+		if !ok {
+			t.Fatalf("could not find %s", fn)
+		}
+		note := strings.Index(body, "noteBackendFailure()")
+		if note < 0 {
+			t.Fatalf("%s no longer records auth failures; the degraded signal lost its transport half", fn)
+		}
+		guarded := strings.Index(body, "if self.ctx.Err() == nil {")
+		if guarded < 0 || note < guarded {
+			t.Fatalf("%s records auth failures without the local-teardown carve-out: a canceled dial would count as a backend failure", fn)
+		}
 	}
 }

--- a/backend_degraded_test.go
+++ b/backend_degraded_test.go
@@ -1,0 +1,225 @@
+package connect
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// The degradation state is package-level, because the flood it guards against
+// is across every transport and sequence at once. These tests therefore reset
+// it rather than constructing an instance, and must not run in parallel.
+func resetBackendDegraded() {
+	consecutiveBackendFails.Store(0)
+	lastBackendFailNano.Store(0)
+}
+
+func TestBackendDegraded_CleanStateIsNotDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	if isBackendDegraded() {
+		t.Fatal("a provider that has never seen a failure must not be degraded")
+	}
+}
+
+func TestBackendDegraded_BelowThresholdIsNotDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	// One or two stray timeouts are normal churn on a busy provider.
+	for i := 0; i < backendDegradedFailThreshold-1; i++ {
+		noteBackendFailure()
+		if isBackendDegraded() {
+			t.Fatalf("degraded after %d failures; threshold is %d", i+1, backendDegradedFailThreshold)
+		}
+	}
+}
+
+func TestBackendDegraded_ThresholdReachedIsDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	if !isBackendDegraded() {
+		t.Fatalf("not degraded after %d consecutive recent failures", backendDegradedFailThreshold)
+	}
+}
+
+// The counter alone is not enough: a stale count left by an old blip on an
+// otherwise idle provider must not read as a live outage.
+func TestBackendDegraded_StaleFailuresAreNotDegraded(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	if !isBackendDegraded() {
+		t.Fatal("precondition: should be degraded before aging the failure")
+	}
+
+	// Age the last failure past the recency window.
+	lastBackendFailNano.Store(time.Now().Add(-backendDegradedWindow - time.Second).UnixNano())
+
+	if isBackendDegraded() {
+		t.Fatalf("still degraded with the last failure older than %s", backendDegradedWindow)
+	}
+}
+
+// Recovery must be immediate on the first good round-trip, not on a timer.
+func TestBackendDegraded_SuccessClearsImmediately(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold+5; i++ {
+		noteBackendFailure()
+	}
+	if !isBackendDegraded() {
+		t.Fatal("precondition: should be degraded")
+	}
+
+	noteBackendSuccess()
+
+	if isBackendDegraded() {
+		t.Fatal("a successful round-trip must clear the degraded state immediately")
+	}
+	if got := consecutiveBackendFails.Load(); got != 0 {
+		t.Fatalf("consecutive failures = %d after success, want 0", got)
+	}
+}
+
+// This is the false-positive guard that matters most: an intermittently failing
+// path that still succeeds sometimes is NOT an outage, however many failures it
+// accumulates in total.
+func TestBackendDegraded_InterleavedSuccessNeverAccumulates(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < 50; i++ {
+		noteBackendFailure()
+		noteBackendFailure()
+		noteBackendSuccess()
+		if isBackendDegraded() {
+			t.Fatalf("degraded on iteration %d despite an interleaved success", i)
+		}
+	}
+}
+
+// Regression: a streak that aged out must not be resumed by a later failure.
+// Before the fix, three stale failures plus one fresh one totalled four with a
+// current timestamp, so the backend read as degraded on the strength of a
+// single recent failure.
+func TestBackendDegraded_StaleStreakIsNotResumedByANewFailure(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	for i := 0; i < backendDegradedFailThreshold; i++ {
+		noteBackendFailure()
+	}
+	// Age the whole streak out of the window, as an idle provider that simply
+	// stopped retrying would.
+	lastBackendFailNano.Store(time.Now().Add(-backendDegradedWindow - time.Minute).UnixNano())
+	if isBackendDegraded() {
+		t.Fatal("precondition: an aged-out streak must not read as degraded")
+	}
+
+	// One new failure. This is the first failure of a fresh streak, not the
+	// fourth of the old one.
+	noteBackendFailure()
+
+	if got := consecutiveBackendFails.Load(); got != 1 {
+		t.Fatalf("consecutive failures = %d after a stale streak plus one failure, want 1", got)
+	}
+	if isBackendDegraded() {
+		t.Fatal("degraded after a single recent failure; the stale streak was resumed instead of reset")
+	}
+}
+
+// The reset must not fire on a gap shorter than the window, or a slow but
+// genuine outage would never accumulate.
+func TestBackendDegraded_StreakSurvivesGapInsideWindow(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	noteBackendFailure()
+	noteBackendFailure()
+	// A gap well inside the window: still the same outage.
+	lastBackendFailNano.Store(time.Now().Add(-backendDegradedWindow / 2).UnixNano())
+
+	noteBackendFailure()
+
+	if got := consecutiveBackendFails.Load(); got != backendDegradedFailThreshold {
+		t.Fatalf("consecutive failures = %d, want %d (streak reset inside the window)", got, backendDegradedFailThreshold)
+	}
+	if !isBackendDegraded() {
+		t.Fatal("not degraded after 3 failures spanning a gap inside the window")
+	}
+}
+
+// Failures and successes arrive concurrently in production: one client's auth
+// can succeed while another's contract OOB fails. The pair must never leave a
+// positive failure count with a zero timestamp, which isBackendDegraded would
+// read as "not degraded" while failures are actually accumulating.
+//
+// This asserts the invariant; it does not reliably reproduce its violation. The
+// window is two adjacent atomic stores, so an unsynchronized noteBackendSuccess
+// still passes this test almost always. The serialization in noteBackendSuccess
+// is what makes the invariant hold, and this guards against a future change that
+// breaks it in a wider, actually-observable way.
+func TestBackendDegraded_ConcurrentSuccessAndFailureNeverLeaveInvalidState(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			noteBackendFailure()
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			noteBackendSuccess()
+		}()
+	}
+	wg.Wait()
+
+	// A positive count always implies a real failure timestamp.
+	if got := consecutiveBackendFails.Load(); 0 < got {
+		if lastBackendFailNano.Load() == 0 {
+			t.Fatalf("invalid state: %d consecutive failures recorded with a zero timestamp", got)
+		}
+	}
+	// And a zeroed timestamp always implies no outstanding failures.
+	if lastBackendFailNano.Load() == 0 {
+		if got := consecutiveBackendFails.Load(); got != 0 {
+			t.Fatalf("invalid state: zero timestamp with %d consecutive failures", got)
+		}
+	}
+}
+
+func TestBackendDegraded_ConcurrentFailuresReachThreshold(t *testing.T) {
+	resetBackendDegraded()
+	defer resetBackendDegraded()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			noteBackendFailure()
+		}()
+	}
+	wg.Wait()
+
+	if got := consecutiveBackendFails.Load(); got != 32 {
+		t.Fatalf("consecutive failures = %d after 32 concurrent failures, want 32", got)
+	}
+	if !isBackendDegraded() {
+		t.Fatal("not degraded after 32 concurrent failures")
+	}
+}

--- a/log_throttle.go
+++ b/log_throttle.go
@@ -1,0 +1,49 @@
+package connect
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// logThrottle rate-limits a high-volume log line to at most one emission per
+// interval, counting how many emissions were suppressed in between so the next
+// allowed line can print a "(N suppressed)" tail.
+//
+// This exists for lines that are individually useful but become a flood under a
+// sustained fault. During a control-API outage every client retries auth and
+// every contract request fails, so `[t]auth error`, `[contract]oob err`,
+// `[ts]->error` and `[r]drop` are emitted continuously by every sequence at
+// once. Throttling keeps the signal (the first line, plus a running suppressed
+// count) while bounding the volume.
+//
+// Concurrency: lock-free. When multiple goroutines race the same interval
+// boundary, exactly one wins the CompareAndSwap and emits; the rest are counted
+// as suppressed. That is the intended rate-limiting behavior, not a lost line.
+type logThrottle struct {
+	intervalNanos int64
+	lastNanos     atomic.Int64
+	suppressed    atomic.Int64
+}
+
+// newLogThrottle creates a log throttle configured with the specified interval.
+func newLogThrottle(interval time.Duration) *logThrottle {
+	return &logThrottle{intervalNanos: int64(interval)}
+}
+
+// Allow reports whether a log line may be emitted as of now. When it returns
+// true, the second value is the number of lines suppressed since the previous
+// allowed line (reset to 0 by this call). When false, the caller should stay
+// quiet; the suppression is counted internally.
+func (t *logThrottle) Allow(now time.Time) (bool, int64) {
+	nowNanos := now.UnixNano()
+	last := t.lastNanos.Load()
+	if nowNanos-last < t.intervalNanos {
+		t.suppressed.Add(1)
+		return false, 0
+	}
+	if !t.lastNanos.CompareAndSwap(last, nowNanos) {
+		t.suppressed.Add(1)
+		return false, 0
+	}
+	return true, t.suppressed.Swap(0)
+}

--- a/log_throttle_fallback_test.go
+++ b/log_throttle_fallback_test.go
@@ -1,0 +1,130 @@
+package connect
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The throttled call sites all follow the same shape:
+//
+//	if ok, suppressed := shouldLogX(); ok {
+//	    log.Infof("... (%d suppressed)", err, suppressed)   // or the plain form
+//	} else if v := log.V(1); v.Enabled() {
+//	    v.Infof("...")                                       // nothing is lost
+//	}
+//
+// Two properties matter and neither is covered by testing logThrottle alone:
+// a suppressed line must still reach V(1) rather than vanish, and the count of
+// suppressed lines must actually appear in the emitted text. These drive that
+// shape through a capturing Logger.
+
+// captureLogger records what was emitted and at which level. verbose reports
+// whether V(n) is enabled, standing in for the process verbosity setting.
+type captureLogger struct {
+	mu      sync.Mutex
+	info    []string
+	verbose []string
+	enabled bool
+}
+
+func (c *captureLogger) Info(args ...any) {}
+func (c *captureLogger) Infof(format string, args ...any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.info = append(c.info, fmt.Sprintf(format, args...))
+}
+func (c *captureLogger) Warningf(format string, args ...any) {}
+func (c *captureLogger) Errorf(format string, args ...any)   {}
+func (c *captureLogger) V(level int32) Verbose               { return &captureVerbose{c: c} }
+
+type captureVerbose struct{ c *captureLogger }
+
+func (v *captureVerbose) Enabled() bool    { return v.c.enabled }
+func (v *captureVerbose) Info(args ...any) {}
+func (v *captureVerbose) Infof(format string, args ...any) {
+	v.c.mu.Lock()
+	defer v.c.mu.Unlock()
+	v.c.verbose = append(v.c.verbose, fmt.Sprintf(format, args...))
+}
+
+// emit reproduces the call-site shape used at every throttled site.
+func emit(log Logger, th *logThrottle, now time.Time, msg string) {
+	if ok, suppressed := th.Allow(now); ok {
+		if suppressed > 0 {
+			log.Infof("%s (%d suppressed)", msg, suppressed)
+		} else {
+			log.Infof("%s", msg)
+		}
+	} else if v := log.V(1); v.Enabled() {
+		v.Infof("%s", msg)
+	}
+}
+
+// With V(1) on, a throttled line must still be emitted at verbose level. This
+// is the "nothing is lost when the level is raised" guarantee.
+func TestThrottledLineFallsBackToVerbose(t *testing.T) {
+	log := &captureLogger{enabled: true}
+	th := newLogThrottle(time.Minute)
+	base := time.Unix(1000, 0)
+
+	emit(log, th, base, "first")                    // allowed -> INFO
+	emit(log, th, base.Add(time.Second), "second")  // throttled -> V(1)
+	emit(log, th, base.Add(2*time.Second), "third") // throttled -> V(1)
+
+	if len(log.info) != 1 {
+		t.Fatalf("expected 1 INFO line, got %d: %v", len(log.info), log.info)
+	}
+	if len(log.verbose) != 2 {
+		t.Fatalf("expected 2 throttled lines to fall back to V(1), got %d: %v", len(log.verbose), log.verbose)
+	}
+	if log.verbose[0] != "second" || log.verbose[1] != "third" {
+		t.Fatalf("wrong lines fell back to V(1): %v", log.verbose)
+	}
+}
+
+// With V(1) off (the production default, -v=0), a throttled line is dropped
+// entirely. That is the point of the throttle: bounded volume under a fault.
+func TestThrottledLineDroppedWhenVerboseDisabled(t *testing.T) {
+	log := &captureLogger{enabled: false}
+	th := newLogThrottle(time.Minute)
+	base := time.Unix(1000, 0)
+
+	emit(log, th, base, "first")
+	emit(log, th, base.Add(time.Second), "second")
+
+	if len(log.info) != 1 {
+		t.Fatalf("expected 1 INFO line, got %d: %v", len(log.info), log.info)
+	}
+	if len(log.verbose) != 0 {
+		t.Fatalf("expected nothing at V(1) when it is disabled, got %v", log.verbose)
+	}
+}
+
+// The suppressed count has to reach the operator, not just the throttle's
+// return value. An outage is only diagnosable if the surviving line says how
+// much it stands for.
+func TestSuppressedCountAppearsInEmittedLine(t *testing.T) {
+	log := &captureLogger{enabled: false}
+	th := newLogThrottle(time.Minute)
+	base := time.Unix(1000, 0)
+
+	emit(log, th, base, "err")
+	for i := 1; i <= 5; i++ {
+		emit(log, th, base.Add(time.Duration(i)*time.Second), "err")
+	}
+	emit(log, th, base.Add(2*time.Minute), "err") // allowed again, reports the 5
+
+	if len(log.info) != 2 {
+		t.Fatalf("expected 2 INFO lines, got %d: %v", len(log.info), log.info)
+	}
+	// The first allowed line stands for itself only, so it carries no tail.
+	if strings.Contains(log.info[0], "suppressed") {
+		t.Fatalf("first line should not report suppressions, got %q", log.info[0])
+	}
+	if !strings.Contains(log.info[1], "(5 suppressed)") {
+		t.Fatalf("expected the next allowed line to report 5 suppressed, got %q", log.info[1])
+	}
+}

--- a/log_throttle_package_vars_test.go
+++ b/log_throttle_package_vars_test.go
@@ -1,0 +1,107 @@
+package connect
+
+import (
+	"testing"
+	"time"
+)
+
+// The package-level throttles (dropErrThrottle in transfer.go, oobErrThrottle
+// in transfer_contract_manager.go, authErrThrottle/writeErrThrottle in
+// transport.go) exist to bound exactly the log lines named in log_throttle.go's
+// doc comment. These tests pin the wiring: each `shouldLog*Err` wrapper must
+// read/write the same persistent, package-level *logThrottle on every call,
+// not construct a fresh one — a fresh one would defeat throttling entirely,
+// since every call would see a zero `lastNanos` and be allowed.
+//
+// The throttles are process-wide state shared with other tests (e.g. any test
+// that drives a real auth/OOB/write failure through the client), so these
+// tests only assert invariants that hold regardless of what came before:
+// "of two calls made back-to-back, at most one is allowed" is true whether
+// the throttle starts fresh or mid-window, but is false for a throttle that
+// resets on every call.
+
+// assertAtMostOneAllowed calls fn twice with no delay and fails if both calls
+// report ok=true. With a one-minute interval, two calls nanoseconds apart can
+// never both fall on the allowed side of a correctly persisted throttle.
+func assertAtMostOneAllowed(t *testing.T, name string, fn func() (bool, int64)) {
+	t.Helper()
+	ok1, _ := fn()
+	ok2, _ := fn()
+	if ok1 && ok2 {
+		t.Fatalf("%s: two back-to-back calls were both allowed; the throttle is not persisted across calls", name)
+	}
+}
+
+func TestShouldLogDropErr_PersistsThrottleAcrossCalls(t *testing.T) {
+	assertAtMostOneAllowed(t, "shouldLogDropErr", shouldLogDropErr)
+}
+
+func TestShouldLogOobErr_PersistsThrottleAcrossCalls(t *testing.T) {
+	assertAtMostOneAllowed(t, "shouldLogOobErr", shouldLogOobErr)
+}
+
+func TestShouldLogAuthErr_PersistsThrottleAcrossCalls(t *testing.T) {
+	assertAtMostOneAllowed(t, "shouldLogAuthErr", shouldLogAuthErr)
+}
+
+func TestShouldLogWriteErr_PersistsThrottleAcrossCalls(t *testing.T) {
+	assertAtMostOneAllowed(t, "shouldLogWriteErr", shouldLogWriteErr)
+}
+
+// A suppressed call never reports a nonzero count itself (only the next
+// *allowed* call reports how many were suppressed before it). This holds for
+// every wrapper's second, necessarily-suppressed-or-equal call above; assert
+// it explicitly for one wrapper as a regression guard on the return contract.
+func TestShouldLogDropErr_SuppressedCallReportsZero(t *testing.T) {
+	_, _ = shouldLogDropErr()
+	ok, suppressed := shouldLogDropErr()
+	if ok {
+		// Extremely unlikely (would require crossing a minute boundary
+		// between the two calls above), but if it happens there is nothing
+		// to assert about "suppressed".
+		t.Skip("second call unexpectedly allowed; interval boundary race")
+	}
+	if suppressed != 0 {
+		t.Fatalf("a suppressed call must report 0, got %d", suppressed)
+	}
+}
+
+// Each throttle is configured for the one-minute window documented in
+// log_throttle.go and in the throttle declarations themselves. This is a
+// same-package white-box check on the exact configured value, guarding
+// against an accidental change to a much shorter (spammy) or longer
+// (over-suppressing) interval.
+func TestPackageLogThrottles_ConfiguredForOneMinute(t *testing.T) {
+	throttles := map[string]*logThrottle{
+		"dropErrThrottle":  dropErrThrottle,
+		"oobErrThrottle":   oobErrThrottle,
+		"authErrThrottle":  authErrThrottle,
+		"writeErrThrottle": writeErrThrottle,
+	}
+	for name, th := range throttles {
+		if th == nil {
+			t.Fatalf("%s is nil", name)
+		}
+		if th.intervalNanos != int64(time.Minute) {
+			t.Fatalf("%s interval = %s, want %s", name, time.Duration(th.intervalNanos), time.Minute)
+		}
+	}
+}
+
+// The four throttles must be four distinct instances. Sharing an instance
+// between call sites (e.g. a copy-paste that reused a variable) would let an
+// auth-error flood suppress an unrelated write-error line, silently losing
+// signal on a fault the throttle was never meant to touch.
+func TestPackageLogThrottles_AreDistinctInstances(t *testing.T) {
+	all := []*logThrottle{dropErrThrottle, oobErrThrottle, authErrThrottle, writeErrThrottle}
+	for i := range all {
+		for j := range all {
+			if i == j {
+				continue
+			}
+			if all[i] == all[j] {
+				t.Fatalf("throttle at index %d and %d are the same instance", i, j)
+			}
+		}
+	}
+}

--- a/log_throttle_test.go
+++ b/log_throttle_test.go
@@ -1,0 +1,144 @@
+package connect
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLogThrottle_FirstCallAllowedZeroSuppressed(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	ok, suppressed := th.Allow(time.Unix(100, 0))
+	if !ok {
+		t.Fatal("first call should be allowed")
+	}
+	if suppressed != 0 {
+		t.Fatalf("first call should report 0 suppressed, got %d", suppressed)
+	}
+}
+
+func TestLogThrottle_SuppressesWithinIntervalThenReportsCount(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	base := time.Unix(1000, 0)
+
+	if ok, _ := th.Allow(base); !ok {
+		t.Fatal("first call should be allowed")
+	}
+	for i := 1; i <= 3; i++ {
+		if ok, _ := th.Allow(base.Add(time.Duration(i) * time.Second)); ok {
+			t.Fatalf("call %ds in (within interval) should be suppressed", i)
+		}
+	}
+
+	ok, suppressed := th.Allow(base.Add(2 * time.Minute))
+	if !ok {
+		t.Fatal("call after the interval elapsed should be allowed")
+	}
+	if suppressed != 3 {
+		t.Fatalf("expected 3 suppressed since the last allowed line, got %d", suppressed)
+	}
+}
+
+func TestLogThrottle_SuppressedCountResetsAfterEmit(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	base := time.Unix(1000, 0)
+
+	th.Allow(base)                      // allowed
+	th.Allow(base.Add(1 * time.Second)) // suppressed -> count 1
+	th.Allow(base.Add(2 * time.Minute)) // allowed, reports & resets count
+
+	// A subsequent allowed line with no suppression in between reports 0.
+	ok, suppressed := th.Allow(base.Add(4 * time.Minute))
+	if !ok || suppressed != 0 {
+		t.Fatalf("expected allowed with 0 suppressed, got ok=%v suppressed=%d", ok, suppressed)
+	}
+}
+
+// The boundary is inclusive: a call landing exactly `interval` after the last
+// allowed one is allowed, not suppressed. `Allow` computes this from a plain
+// duration subtraction ("now - last < interval"), so this pins the boundary
+// against an off-by-one in either direction.
+func TestLogThrottle_ExactIntervalBoundaryIsAllowed(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	base := time.Unix(1000, 0)
+
+	if ok, _ := th.Allow(base); !ok {
+		t.Fatal("first call should be allowed")
+	}
+	// One nanosecond short of the interval: still suppressed.
+	if ok, _ := th.Allow(base.Add(time.Minute - time.Nanosecond)); ok {
+		t.Fatal("call 1ns short of the interval should be suppressed")
+	}
+	// Exactly the interval: allowed.
+	ok, suppressed := th.Allow(base.Add(time.Minute))
+	if !ok {
+		t.Fatal("call exactly at the interval boundary should be allowed")
+	}
+	if suppressed != 1 {
+		t.Fatalf("expected 1 suppressed (the short call above), got %d", suppressed)
+	}
+}
+
+// A negative interval (misconfiguration) must not panic or wedge the
+// throttle into always-suppress: `Allow` should degrade to "always allow"
+// since `now - last` can never be less than a negative interval.
+func TestLogThrottle_NonPositiveIntervalAlwaysAllows(t *testing.T) {
+	th := newLogThrottle(0)
+	base := time.Unix(1000, 0)
+
+	for i := 0; i < 3; i++ {
+		ok, _ := th.Allow(base.Add(time.Duration(i) * time.Nanosecond))
+		if !ok {
+			t.Fatalf("call %d with a zero interval should be allowed, was suppressed", i)
+		}
+	}
+}
+
+// A real outage drives every sequence at the fault simultaneously. Exactly one
+// caller may emit per interval; the rest must be counted, not lost.
+func TestLogThrottle_ConcurrentCallersEmitOncePerInterval(t *testing.T) {
+	th := newLogThrottle(time.Minute)
+	now := time.Unix(2000, 0)
+
+	const callers = 64
+	allowed := make(chan int64, callers)
+	start := make(chan struct{})
+	done := make(chan struct{})
+
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			<-start
+			if ok, suppressed := th.Allow(now); ok {
+				allowed <- suppressed
+			}
+		}()
+	}
+	close(start)
+	for i := 0; i < callers; i++ {
+		<-done
+	}
+	close(allowed)
+
+	emitted := 0
+	var reportedByWinner int64
+	for suppressed := range allowed {
+		emitted++
+		reportedByWinner += suppressed
+	}
+	if emitted != 1 {
+		t.Fatalf("expected exactly 1 emission across %d concurrent callers, got %d", callers, emitted)
+	}
+
+	// The winner's Swap(0) races the losers' Add(1): both happen after the
+	// winner's CompareAndSwap, so a loser that increments first is reported by
+	// the winning call rather than the next one. Either split is correct, so
+	// assert on the total. What must hold is that no suppression is lost.
+	ok, suppressed := th.Allow(now.Add(2 * time.Minute))
+	if !ok {
+		t.Fatal("call after the interval elapsed should be allowed")
+	}
+	if total := reportedByWinner + suppressed; total != callers-1 {
+		t.Fatalf("expected %d suppressed in total, got %d (%d reported by the winning call, %d by the next)",
+			callers-1, total, reportedByWinner, suppressed)
+	}
+}

--- a/transfer.go
+++ b/transfer.go
@@ -63,6 +63,14 @@ const defaultTransferBufferSize = 32
 
 var DebugTransferCopyOnWrite = false
 
+// dropErrThrottle rate-limits `[r]drop`. A route that stops accepting writes
+// produces one of these per dropped frame, which under a sustained fault is
+// per-message. See logThrottle in log_throttle.go.
+var dropErrThrottle = newLogThrottle(time.Minute)
+
+// shouldLogDropErr determines whether a receive-side route drop error should be logged and reports the number of previously suppressed errors.
+func shouldLogDropErr() (bool, int64) { return dropErrThrottle.Allow(time.Now()) }
+
 // AckFunction is invoked inline by the owning send path. Blocking is
 // intentional backpressure: callers can stop completion from outrunning their
 // downstream state. Do not move it to a lossy/coalescing observer worker.
@@ -3266,12 +3274,21 @@ func (self *SendSequence) updateContract(messageByteCount ByteCount) bool {
 			}
 			if contract := self.client.ContractManager().TakeContract(self.ctx, contractKey, timeout); contract != nil && setNextContract(contract) {
 				self.contractSeqIndex += 1
-				// async queue up the next contract
-				self.client.ContractManager().CreateContract(
-					contractKey,
-					self.contractSeqIndex,
-					ByteCount(32+float32(messageByteCount+self.sendBufferSettings.MinMessageByteCount)/self.sendBufferSettings.ContractFillFraction),
-				)
+				// async queue up the next contract.
+				//
+				// Skipped while the backend is unreachable. A sequence that
+				// still holds queued contracts keeps satisfying TakeContract,
+				// so without this check it would keep prefetching and keep the
+				// OOB storm going for exactly the sequences that still have
+				// work to do. The contract just taken is unaffected: only the
+				// prefetch of the following one waits for the backend.
+				if !isBackendDegraded() {
+					self.client.ContractManager().CreateContract(
+						contractKey,
+						self.contractSeqIndex,
+						ByteCount(32+float32(messageByteCount+self.sendBufferSettings.MinMessageByteCount)/self.sendBufferSettings.ContractFillFraction),
+					)
+				}
 				return true
 			} else {
 				return false
@@ -3295,6 +3312,13 @@ func (self *SendSequence) updateContract(messageByteCount ByteCount) bool {
 		maxRetryInterval := self.sendBufferSettings.CreateContractRetryMaxInterval
 		if maxRetryInterval <= 0 {
 			maxRetryInterval = retryInterval
+		}
+		// The fast first retry exists to cover a single dropped control
+		// message. While the backend is unreachable there is nothing to cover:
+		// no contract can be authorized until it returns, so start at the
+		// backed-off interval instead of walking up from 1s on every sequence.
+		if isBackendDegraded() {
+			retryInterval = maxRetryInterval
 		}
 
 		if self.sendContract != nil {
@@ -3327,11 +3351,20 @@ func (self *SendSequence) updateContract(messageByteCount ByteCount) bool {
 				EncryptionRole:      self.encryptionRole,
 				EncryptionCompanion: self.encryptionCompanion,
 			}
-			self.client.ContractManager().CreateContract(
-				contractKey,
-				self.contractSeqIndex,
-				ByteCount(32+float32(messageByteCount+messageByteCount+self.sendBufferSettings.MinMessageByteCount)/self.sendBufferSettings.ContractFillFraction),
-			)
+			// Skip the request entirely while the backend is unreachable. Each
+			// CreateContract is an OOB control round-trip; with the API down
+			// every one of them fails, and on a provider carrying many
+			// sequences that is a continuous storm of requests that cannot
+			// succeed. The loop still waits out the retry interval, so the
+			// sequence resumes promptly once a successful auth or OOB
+			// round-trip clears the degraded state.
+			if !isBackendDegraded() {
+				self.client.ContractManager().CreateContract(
+					contractKey,
+					self.contractSeqIndex,
+					ByteCount(32+float32(messageByteCount+messageByteCount+self.sendBufferSettings.MinMessageByteCount)/self.sendBufferSettings.ContractFillFraction),
+				)
+			}
 
 			if traceNextContract(min(timeout, retryInterval)) {
 				return true
@@ -4981,7 +5014,15 @@ func (self *ReceiveSequence) Run() {
 			} else {
 				err := c()
 				if err != nil {
-					self.log.Infof("[r]drop = %s", err)
+					if ok, suppressed := shouldLogDropErr(); ok {
+						if suppressed > 0 {
+							self.log.Infof("[r]drop = %s (%d suppressed)", err, suppressed)
+						} else {
+							self.log.Infof("[r]drop = %s", err)
+						}
+					} else if v := self.log.V(1); v.Enabled() {
+						v.Infof("[r]drop = %s", err)
+					}
 				}
 			}
 		}

--- a/transfer_contract_manager.go
+++ b/transfer_contract_manager.go
@@ -25,6 +25,15 @@ import (
 
 // manage contracts which are embedded into each transfer sequence
 
+// oobErrThrottle rate-limits `[contract]oob err`. During a control-API outage
+// every sequence's contract request fails, so this line is emitted once per
+// sequence per retry across the whole client. See logThrottle in
+// log_throttle.go.
+var oobErrThrottle = newLogThrottle(time.Minute)
+
+// shouldLogOobErr reports whether an out-of-band error should be logged and the number of errors suppressed since the previous allowed log.
+func shouldLogOobErr() (bool, int64) { return oobErrThrottle.Allow(time.Now()) }
+
 type ContractKey struct {
 	Destination       TransferPath
 	IntermediaryIds   MultiHopId
@@ -1298,6 +1307,8 @@ func (self *ContractManager) CreateContract(contractKey ContractKey, contractSeq
 		[]*protocol.Frame{frame},
 		func(resultFrames []*protocol.Frame, err error) {
 			if err == nil {
+				// the OOB round-trip completed: the backend is reachable
+				noteBackendSuccess()
 				for _, resultFrame := range resultFrames {
 					self.HandleControlFrame(contractKey, resultFrame)
 				}
@@ -1306,7 +1317,16 @@ func (self *ContractManager) CreateContract(contractKey ContractKey, contractSeq
 				case <-self.client.Done():
 					// no need to log warnings when the client closes
 				default:
-					self.client.log.Infof("[contract]oob err = %s\n", err)
+					noteBackendFailure()
+					if ok, suppressed := shouldLogOobErr(); ok {
+						if suppressed > 0 {
+							self.client.log.Infof("[contract]oob err = %s (%d suppressed)\n", err, suppressed)
+						} else {
+							self.client.log.Infof("[contract]oob err = %s\n", err)
+						}
+					} else if v := self.client.log.V(1); v.Enabled() {
+						v.Infof("[contract]oob err = %s\n", err)
+					}
 				}
 			}
 		},

--- a/transport.go
+++ b/transport.go
@@ -98,6 +98,117 @@ func (self *ClientAuth) ClientId() (Id, error) {
 	return byJwt.ClientId, nil
 }
 
+// Throttles for the log lines that flood during a control-API outage. Each is
+// package-level because the flood is across every transport and sequence at
+// once, not within one of them — a per-instance limiter would still emit once
+// per client per interval, which on a provider with thousands of clients is not
+// a limit at all. See logThrottle in log_throttle.go.
+var (
+	authErrThrottle  = newLogThrottle(time.Minute)
+	writeErrThrottle = newLogThrottle(time.Minute)
+)
+
+// shouldLogAuthErr reports whether an authentication error should be logged and returns the throttle state.
+func shouldLogAuthErr() (bool, int64) { return authErrThrottle.Allow(time.Now()) }
+
+// shouldLogWriteErr reports whether a write error should be logged and returns the associated throttle value.
+func shouldLogWriteErr() (bool, int64) { return writeErrThrottle.Allow(time.Now()) }
+
+// lastBackendFailNano is the time of the most recent backend failure (auth or
+// contract OOB), in unix nanos. Not throttled — every failure updates it, so
+// isBackendDegraded can tell a live outage from a stale count left by an old
+// blip on an otherwise idle provider.
+var lastBackendFailNano atomic.Int64
+
+// consecutiveBackendFails counts backend failures since the last success. Any
+// successful auth or OOB round-trip resets it to 0. A real platform outage
+// drives this up quickly because every attempt fails with nothing to reset it;
+// isolated transient timeouts never accumulate, because an interleaved success
+// clears the count.
+//
+// This is process-wide rather than per-Client on purpose: "is the control API
+// reachable from this host" is a property of the host, not of any one client.
+// A host running many clients gets a stronger signal from sharing the counter,
+// because a success on any client clears it — so a single misbehaving client
+// cannot trip the threshold on its own, and only a fault broad enough to fail
+// every client in a row reads as an outage. That is exactly the distinction
+// isBackendDegraded is trying to draw.
+var consecutiveBackendFails atomic.Int64
+
+// backendDegradedFailThreshold is how many consecutive backend failures (with
+// no intervening success) are required before the backend is treated as
+// degraded. Set above the level of normal transient churn so a stray timeout on
+// a busy provider is never mistaken for an outage.
+const backendDegradedFailThreshold = 3
+
+// backendDegradedWindow is how recent the last failure must be for the counter
+// to be trusted. Comfortably larger than the 60s reconnect-backoff cap, so a
+// real outage's retries always read as recent.
+const backendDegradedWindow = 2 * time.Minute
+
+// isBackendDegraded reports whether backend failures have accumulated past the
+// threshold with no intervening success, and the last one is recent. It
+// distinguishes a sustained outage (every attempt failing) from the isolated
+// single-connection timeouts that are normal churn.
+//
+// Callers use it to avoid queueing work that cannot complete: with the control
+// API unreachable, no client can authorize a contract, so contract creation,
+// contract retry pacing, and window expansion are all spending bandwidth on
+// data that has nowhere to go.
+func isBackendDegraded() bool {
+	if consecutiveBackendFails.Load() < backendDegradedFailThreshold {
+		return false
+	}
+	return time.Now().UnixNano()-lastBackendFailNano.Load() < int64(backendDegradedWindow)
+}
+
+// backendFailMu serializes the failure-state transition. Recording a failure is
+// a single logical step made of three stores (age out a dead streak, adjust the
+// counter, refresh the timestamp); interleaving them could half-clear a stale
+// streak and leave it readable as live. Backend failures are rare by definition,
+// so serializing them costs nothing, and isBackendDegraded stays lock-free.
+var backendFailMu sync.Mutex
+
+// noteBackendFailure records a failed backend round-trip (auth or contract OOB).
+//
+// A streak older than backendDegradedWindow is discarded rather than extended.
+// Without that, an idle provider that saw a few failures long ago and simply
+// stopped retrying would carry the old count forward: the next single failure
+// would push the total past the threshold with a fresh timestamp, and the
+// backend would read as degraded on the strength of one recent failure. The
+// threshold means "consecutive failures within the window", so a gap that
+// invalidates the streak for isBackendDegraded must also reset it here.
+func noteBackendFailure() {
+	now := time.Now().UnixNano()
+
+	backendFailMu.Lock()
+	defer backendFailMu.Unlock()
+
+	last := lastBackendFailNano.Load()
+	if last != 0 && int64(backendDegradedWindow) <= now-last {
+		consecutiveBackendFails.Store(1)
+	} else {
+		consecutiveBackendFails.Add(1)
+	}
+	lastBackendFailNano.Store(now)
+}
+
+// noteBackendSuccess clears the degradation state after a backend round-trip
+// noteBackendSuccess clears the recorded backend failure state after a successful operation.
+// It takes backendFailMu for the same reason noteBackendFailure does: clearing
+// the count and the timestamp is one logical transition. Unsynchronized, a
+// concurrent failure could land its increment and timestamp between the two
+// stores here, leaving a positive count with a zero timestamp — a state
+// isBackendDegraded reads as "not degraded" while failures are in fact
+// accumulating.
+func noteBackendSuccess() {
+	backendFailMu.Lock()
+	defer backendFailMu.Unlock()
+
+	consecutiveBackendFails.Store(0)
+	lastBackendFailNano.Store(0)
+}
+
 // (ctx, network, address)
 // type DialContextFunc func(ctx context.Context, network string, address string) (net.Conn, error)
 
@@ -668,7 +779,17 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 		}
 		releaseReconnect()
 		if err != nil {
-			self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+			noteBackendFailure()
+			if ok, suppressed := shouldLogAuthErr(); ok {
+				if suppressed > 0 {
+					self.log.Infof("[t]auth error %s = %s (%d suppressed)\n", clientId, err, suppressed)
+				} else {
+					self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+				}
+			} else if v := self.log.V(1); v.Enabled() {
+				// throttled at INFO; -v=1 still shows every attempt
+				v.Infof("[t]auth error %s = %s\n", clientId, err)
+			}
 			select {
 			case <-self.ctx.Done():
 				return
@@ -683,6 +804,9 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 				continue
 			}
 		}
+
+		// auth succeeded: the backend is reachable
+		noteBackendSuccess()
 
 		c := func() {
 			defer ws.Close()
@@ -851,7 +975,15 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 					MessagePoolReturn(message)
 					if err != nil {
 						// note that for websocket a dealine timeout cannot be recovered
-						self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+						if ok, suppressed := shouldLogWriteErr(); ok {
+							if suppressed > 0 {
+								self.log.Infof("[ts]%s-> error = %s (%d suppressed)\n", clientId, err, suppressed)
+							} else {
+								self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+							}
+						} else if v := self.log.V(1); v.Enabled() {
+							v.Infof("[ts]%s-> error = %s\n", clientId, err)
+						}
 						return err
 					}
 					if self.log.V(2).Enabled() {
@@ -1416,7 +1548,17 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 		}
 		releaseReconnect()
 		if err != nil {
-			self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+			noteBackendFailure()
+			if ok, suppressed := shouldLogAuthErr(); ok {
+				if suppressed > 0 {
+					self.log.Infof("[t]auth error %s = %s (%d suppressed)\n", clientId, err, suppressed)
+				} else {
+					self.log.Infof("[t]auth error %s = %s\n", clientId, err)
+				}
+			} else if v := self.log.V(1); v.Enabled() {
+				// throttled at INFO; -v=1 still shows every attempt
+				v.Infof("[t]auth error %s = %s\n", clientId, err)
+			}
 			select {
 			case <-self.ctx.Done():
 				return
@@ -1429,6 +1571,10 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 				continue
 			}
 		}
+
+		// auth succeeded: the backend is reachable
+		noteBackendSuccess()
+
 		conn := connStream.conn
 		stream := connStream.stream
 
@@ -1569,7 +1715,15 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 						MessagePoolReturn(message)
 						if err != nil {
 							// note that for websocket a dealine timeout cannot be recovered
-							self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+							if ok, suppressed := shouldLogWriteErr(); ok {
+								if suppressed > 0 {
+									self.log.Infof("[ts]%s-> error = %s (%d suppressed)\n", clientId, err, suppressed)
+								} else {
+									self.log.Infof("[ts]%s-> error = %s\n", clientId, err)
+								}
+							} else if v := self.log.V(1); v.Enabled() {
+								v.Infof("[ts]%s-> error = %s\n", clientId, err)
+							}
 							return
 						}
 						if self.log.V(2).Enabled() {

--- a/transport.go
+++ b/transport.go
@@ -128,6 +128,11 @@ var lastBackendFailNano atomic.Int64
 //
 // This is process-wide rather than per-Client on purpose: "is the control API
 // reachable from this host" is a property of the host, not of any one client.
+// The known limit of that framing: a process talking to MULTIPLE platform urls
+// (separate network spaces) shares one signal across them, so a dead custom
+// endpoint can gate a healthy one. Accepted for now -- the fleet and app cases
+// run one platform per process -- and keying this state by platform url is the
+// upgrade path if that changes.
 // A host running many clients gets a stronger signal from sharing the counter,
 // because a success on any client clears it — so a single misbehaving client
 // cannot trip the threshold on its own, and only a fault broad enough to fail
@@ -155,6 +160,16 @@ const backendDegradedWindow = 2 * time.Minute
 // API unreachable, no client can authorize a contract, so contract creation,
 // contract retry pacing, and window expansion are all spending bandwidth on
 // data that has nowhere to go.
+//
+// During an outage where the transport stays connected (the control API down,
+// the websocket alive), auth never re-runs and the gated CreateContract is the
+// only other success source -- so nothing can SUCCEED to clear the state.
+// Recovery then rides the recency window instead: after backendDegradedWindow
+// without failures this reads false, the sequences that tick before three
+// fresh failures land probe the backend, and either one succeeds (clearing the
+// state) or the gate re-trips. The steady state of a long OOB-only outage is
+// therefore a bounded probe burst every ~backendDegradedWindow, not a latched
+// stop -- which is also what makes recovery need no timer of its own.
 func isBackendDegraded() bool {
 	if consecutiveBackendFails.Load() < backendDegradedFailThreshold {
 		return false
@@ -193,8 +208,8 @@ func noteBackendFailure() {
 	lastBackendFailNano.Store(now)
 }
 
-// noteBackendSuccess clears the degradation state after a backend round-trip
-// noteBackendSuccess clears the recorded backend failure state after a successful operation.
+// noteBackendSuccess clears the recorded backend failure state after a
+// successful auth or OOB round-trip.
 // It takes backendFailMu for the same reason noteBackendFailure does: clearing
 // the count and the timestamp is one logical transition. Unsynchronized, a
 // concurrent failure could land its increment and timestamp between the two
@@ -779,7 +794,16 @@ func (self *PlatformTransport) runH1(initialTimeout time.Duration) {
 		}
 		releaseReconnect()
 		if err != nil {
-			noteBackendFailure()
+			// a canceled dial is local teardown -- this transport or its owner
+			// shutting down mid-connect -- not a backend signal. Without this
+			// carve-out, closing a multi-client window cancels many transports
+			// at once and the burst of canceled dials trips the degraded
+			// threshold with fresh timestamps, so the NEXT session starts
+			// gated. The contract OOB path makes the same carve-out on
+			// client.Done.
+			if self.ctx.Err() == nil {
+				noteBackendFailure()
+			}
 			if ok, suppressed := shouldLogAuthErr(); ok {
 				if suppressed > 0 {
 					self.log.Infof("[t]auth error %s = %s (%d suppressed)\n", clientId, err, suppressed)
@@ -1548,7 +1572,16 @@ func (self *PlatformTransport) runH3(ptMode TransportMode, initialTimeout time.D
 		}
 		releaseReconnect()
 		if err != nil {
-			noteBackendFailure()
+			// a canceled dial is local teardown -- this transport or its owner
+			// shutting down mid-connect -- not a backend signal. Without this
+			// carve-out, closing a multi-client window cancels many transports
+			// at once and the burst of canceled dials trips the degraded
+			// threshold with fresh timestamps, so the NEXT session starts
+			// gated. The contract OOB path makes the same carve-out on
+			// client.Done.
+			if self.ctx.Err() == nil {
+				noteBackendFailure()
+			}
 			if ok, suppressed := shouldLogAuthErr(); ok {
 				if suppressed > 0 {
 					self.log.Infof("[t]auth error %s = %s (%d suppressed)\n", clientId, err, suppressed)


### PR DESCRIPTION
## Stop leaking bandwidth when the control API is unreachable

When the control API is unreachable, a provider keeps requesting contracts against an
endpoint that cannot authorize anything. Every sequence retries on its own schedule, so the
requests never stop, and none of them can succeed until the API returns. On metered links,
which is the common case for proxy providers, a sustained outage can burn a large share of a
monthly allowance while serving no traffic.

The root problem is that nothing tells the provider the backend is down. This PR adds that
signal and uses it.

### The signal

`isBackendDegraded()` is true only when **both** hold: at least
`backendDegradedFailThreshold` (3) consecutive failures with no intervening success, and the
most recent failure is within `backendDegradedWindow` (2 minutes). It is fed by the only two
round-trips that actually touch the backend: platform transport auth, and the contract OOB
request.

The consecutive-failure requirement is what separates a real outage from normal churn.
Isolated timeouts happen constantly on a busy provider, but they are interleaved with
successes, and any success resets the counter. A real outage fails every attempt with
nothing to reset it. The recency window then stops a stale count, left by an old blip on an
idle provider, from reading as a live outage.

> [!NOTE]
> The threshold is deliberately conservative. Reacting after three consecutive failures is
> slower than reacting to the first, and that is the intended trade: a false positive stalls
> contract creation for a provider whose backend is fine, which is worse than a few extra
> seconds of leak at the start of a real outage.

### What is gated while degraded

| Gate | Why |
|---|---|
| `CreateContract` is skipped | Each call is an OOB round-trip. With the API down every one fails, and a provider carrying many sequences produces a continuous storm of requests that cannot succeed. |
| Contract retries start at the backed-off interval | The fast first retry exists to cover a single dropped control message. During an outage there is nothing to cover, so walking up from 1s on every sequence is wasted. Composes with the existing `nextCreateContractRetryInterval` backoff rather than replacing it. |

Each gate is a skip, not a teardown. Nothing is discarded, and sequences resume on their
normal path as soon as a successful round-trip clears the state.

### Log throttling for the same fault

The same outage floods the logs: `[t]auth error`, `[contract]oob err`, `[ts]->error` and
`[r]drop` are emitted per sequence per retry, so they become the dominant volume and can push
out the lines needed to diagnose the problem. Each is now limited to one line per minute with
an `(N suppressed)` tail, via a small shared `logThrottle`, falling back to `V(1)` so nothing
is lost at higher verbosity.

The throttles are package level rather than per instance. A per-instance limiter would still
emit once per client per interval, which on a provider with thousands of clients is not a
limit at all. `logThrottle.Allow` is lock free: when goroutines race the same interval
boundary exactly one emits and the rest are counted, which is covered by a test.

### Validation

The detection and gating have been running in production on a provider fleet
(https://github.com/full-bars/urnetwork-3.23-fix) for several months, across real
control-API outages. The thresholds, window and gates here are the values that fleet runs,
not new tuning proposed in this PR.

The effect is large: with contract creation gated and retries paced back, bandwidth consumption drops
to a small fraction of baseline for the duration of the outage. Two honest caveats. It
reduces the leak rather than eliminating it, since data already in flight still drains. And
traffic briefly rises after recovery as queued work clears, which is queues draining rather
than useful transfer resuming.

### Deliberately not included

- **No resend-timeout backoff.** `SendSequence` already backs off multiplicatively per resend
  and caps at `MaxResendInterval`. Nothing to add.
- **No OOB error backoff.** An earlier draft (#180) muted contract creation for a minute after
  a *single* OOB failure. Dropped: it never ran in production, and triggering on one failure is
  exactly the false positive the 3-failure threshold exists to prevent.
- **No log level changes.** Every line keeps its current level. This changes how often a line
  is emitted under sustained fault, never whether it is emitted.

### Supersedes

Replaces #180 and #182, which overlapped badly (each rewrote the same log lines, and both
declared the same helper functions, so they could not merge in either order) and both went
stale. This is the two of them refreshed against current main as one change, minus the parts
upstream has since solved on its own.

### Related issues

Addresses the control-plane half of #175 and #181: the retry storm against an unreachable
API, and the log flooding it produces. #181 point 3, "no global circuit breaker", is what
`isBackendDegraded` provides.

Neither issue is fully resolved here. #175 also reports file-descriptor and memory growth
during outages, which this does not touch. #181 also covers resend-queue amplification,
which upstream's existing multiplicative resend backoff already mitigates, and multi-client
window expansion, which is left alone deliberately.
