### PR TITLE
Linux: egress-bound control-plane resolver, rate-limit backoff, and provider window redundancy

### DIFF
--- a/egress_dial.go
+++ b/egress_dial.go
@@ -34,17 +34,34 @@ import (
 // Everything here is inert unless an egress interface is set: mobile and
 // desktop app builds keep the platform resolver they always had.
 
-// egressBound reports whether an egress interface is currently forced, which
-// is true exactly while this process provides a tunnel (the Windows service in
-// Connecting/Connected, and the Windows app while the tunnel is up).
+// egressSelfExcluded is the platform's answer to "are this process's own
+// sockets steered around the tunnel it provides by something other than a
+// forced interface index". Only Linux sets it (from an init in
+// egress_resolver_linux.go): urnetwork-linux excludes the daemon with an
+// fwmark stamped at socket creation by a cgroup-BPF program, never with
+// IP_UNICAST_IF, so EgressInterfaceIndex stays zero there even while the
+// tunnel is up and this file's escapes would otherwise all read "unbound".
+// Nil — the value on Windows and on every other platform — means the interface
+// index is the whole story, exactly as before.
+var egressSelfExcluded func() bool
+
+// egressBound reports whether this process's own sockets are currently steered
+// around the tunnel it provides, which is true exactly while this process
+// provides a tunnel: the Windows service in Connecting/Connected and the
+// Windows app while the tunnel is up (a forced egress interface), and the Linux
+// daemon once its cgroup program is attached (the egress fwmark).
 func egressBound() bool {
 	index4, index6 := EgressInterfaceIndex()
-	return index4 != 0 || index6 != 0
+	if index4 != 0 || index6 != 0 {
+		return true
+	}
+	return egressSelfExcluded != nil && egressSelfExcluded()
 }
 
 // egressAwareResolver returns the resolver control dials should use: the
 // caller's own resolver when one is configured, else the platform's
-// egress-bound in-process resolver (Windows), else nil (the OS resolver).
+// egress-bound in-process resolver (Windows always, Linux while this process
+// is the tunnel daemon), else nil (the OS resolver).
 func egressAwareResolver(custom *net.Resolver) *net.Resolver {
 	if custom != nil {
 		return custom
@@ -52,11 +69,15 @@ func egressAwareResolver(custom *net.Resolver) *net.Resolver {
 	return egressResolver()
 }
 
-// resolveEgressUDPAddr is net.ResolveUDPAddr for control dials: while an
-// egress interface is forced it resolves through the egress-bound resolver
-// instead of the OS resolver, preferring an address family the bind can
-// actually carry. Off Windows / with no egress set it is exactly
-// net.ResolveUDPAddr.
+// resolveEgressUDPAddr is net.ResolveUDPAddr for control dials: while this
+// process's own sockets are steered around the tunnel it provides, it resolves
+// through the egress-bound resolver instead of the OS resolver, preferring an
+// address family the bind can actually carry. On a platform with no egress
+// escape, or with none in force, it is exactly net.ResolveUDPAddr.
+//
+// This is the H3/QUIC platform transport's name path (transport.go), and it is
+// the second half of the Linux fix: pinning the resolver into NetDialer alone
+// would leave these three call sites resolving through the captured stub.
 func resolveEgressUDPAddr(ctx context.Context, addr string) (*net.UDPAddr, error) {
 	resolver := egressResolver()
 	if resolver == nil || !egressBound() {

--- a/egress_resolver_linux.go
+++ b/egress_resolver_linux.go
@@ -1,0 +1,475 @@
+//go:build linux && !android
+
+package connect
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// The egress-bound in-process resolver for Linux. egress_resolver_windows.go
+// is the reference implementation; this is the same escape by a different
+// mechanism. See the file comment in egress_dial.go for why it exists at all.
+//
+// WHY LINUX NEEDS ITS OWN, WHEN THE !windows STUB SAID IT DID NOT. The stub's
+// claim was that off Windows the OS resolver is already tunnel-aware, because
+// macOS network extensions and Android VpnService route the extension's own
+// lookups correctly. That is true of macOS and Android and FALSE OF LINUX, and
+// the Linux client's own configuration is what makes it false:
+//
+//   - urnetwork-linux applies a per-link resolver to its tun (urnet0) with
+//     domain `~.` — the default route for names — via resolvectl. From that
+//     moment systemd-resolved sends EVERY lookup on the machine through the
+//     tunnel, and the tun's advertised resolver is the UpgradeMux mask address
+//     (sdk.GetDefaultTunnelDnsAddressIpv4 == DefaultDnsUpgradeMaskAddress),
+//     which only answers once the tunnel carries traffic.
+//   - the daemon's OWN sockets escape that, but by a mechanism that does not
+//     extend to its lookups: a cgroup-BPF sock_create program stamps
+//     egressSocketMark on every socket this process creates, and the client's
+//     `ip rule not fwmark <mark> table <capture>` policy rule keeps marked
+//     sockets out of the tun. systemd-resolved is a SEPARATE PROCESS in a
+//     DIFFERENT CGROUP, so the query it re-issues on the daemon's behalf
+//     carries no mark and goes into the tunnel.
+//
+// The result is the same deadlock the Windows service had, reached by a
+// different road: tunnel up -> all DNS routed through it -> the provider
+// window empties -> the daemon needs DNS to reach the platform api to fetch
+// new providers -> that lookup goes into the dead tunnel -> the window never
+// refills. An already-established platform connection keeps working (no name
+// to resolve), which is exactly the observed signature: contracts still being
+// created on the live connection while every NEW transport times out.
+//
+// THE ESCAPE, mirroring the Windows file: PreferGo makes net use its own
+// resolver machinery instead of the platform stub, and the custom Dial gives
+// every wire query a socket that leaves via the physical interface. The Go
+// resolver hands Dial the server IT chose from /etc/resolv.conf — on a
+// systemd-resolved machine that is the 127.0.0.53 stub, the exact dead end
+// this resolver exists to avoid — so Dial keeps only the port and substitutes
+// a server that is reachable off-tunnel: the physical link's own resolvers,
+// or the well-known public resolvers when none can be read.
+//
+// THE BUILD TAG CARRIES `!android` ON PURPOSE. Go sets the `linux` tag for
+// GOOS=android as well (and applies the `_linux.go` name suffix there too), so
+// a bare `linux` would put this file in the mobile SDK — where a PreferGo
+// resolver resolves nothing, because Android has no /etc/resolv.conf and its
+// DNS configuration lives in system properties. That is what the wlynxg/anet
+// dependency exists to work around, and VpnService.protect already handles
+// Android's self-exclusion. Android therefore keeps egress_resolver_other.go,
+// whose tag is the exact complement of this one.
+//
+// AND IT IS STILL INERT ON ANY LINUX THAT IS NOT THE TUNNEL DAEMON. Desktop
+// Linux is not one platform, it is every embedding of this SDK: headless
+// providers on servers with split-horizon resolvers, CI, other applications.
+// None of those have a captured resolver and none of them should have their
+// DNS rerouted. egressResolver therefore returns nil — the platform resolver,
+// byte-for-byte the old behavior — unless this process is demonstrably the
+// tunnel-providing daemon. The test for that is egressSelfMarked: a socket
+// created right now is born carrying egressSocketMark, which happens only
+// inside the cgroup urnetwork-linux attached its program to. Nothing in a
+// container, in CI, or in any other embedding can satisfy it by accident.
+
+// egressSocketMark is the fwmark urnetwork-linux's cgroup-BPF sock_create
+// program stamps on every AF_INET/AF_INET6 socket this process creates
+// ("URNW" as a u32; urnetwork-linux Tunnel.hpp kEgressMark). A socket carrying
+// it is excluded from the capture route table by the client's policy rule and
+// accepted by its firewall's mark rule, so it leaves via the physical
+// interface and never enters the tun.
+const egressSocketMark = 0x55524e57
+
+// egressBoundResolver is the resolver control dials use while this process
+// provides a tunnel. Same shape as the Windows one: the in-process Go resolver
+// plus a Dial that substitutes an off-tunnel server on an off-tunnel socket.
+var egressBoundResolver = &net.Resolver{
+	PreferGo: true,
+	Dial:     egressResolverDial,
+}
+
+// egressResolver returns the egress-bound resolver only when this process's
+// own sockets are steered around the tunnel it provides. Off that path — every
+// headless or embedded use of this SDK, every Linux host that is not running
+// the tunnel daemon — it returns nil, which means net.Dialer keeps
+// net.DefaultResolver exactly as before.
+//
+// THE GATE IS INSIDE Dial, NOT HERE, and that is load-bearing rather than
+// stylistic. ConnectSettings.NetDialer() is called ONCE for the primary
+// control dialer — newNormalDialTlsContext builds a tls.Dialer around it and
+// returns its DialContext — so whatever this function answers at construction is frozen
+// into that dialer for the process's life. Gating here returned nil to every
+// caller constructed before the daemon's cgroup-BPF program attaches, and the
+// fix would then never engage no matter how marked the process later became:
+// present in the binary, invoked by nothing. Handing the resolver out
+// unconditionally and asking egressSelfMarked() per query makes the answer
+// track reality, and matches egress_resolver_windows.go exactly.
+func egressResolver() *net.Resolver {
+	return egressBoundResolver
+}
+
+func init() {
+	// egressBound() — and with it the control-dial evidence lines and
+	// resolveEgressUDPAddr's escape for the H3/QUIC platform transports — asks
+	// this hook whether the platform excludes its own sockets by some means
+	// other than a forced interface index. On Linux that means is the fwmark.
+	egressSelfExcluded = egressSelfMarked
+}
+
+// egressResolverDialTimeout bounds one wire query's dial. The Go resolver
+// applies its own per-query timeout and retries across servers; this only
+// keeps a single dead server from consuming the whole budget.
+const egressResolverDialTimeout = 5 * time.Second
+
+// egressResolverRotation rotates server choice across Dial calls, so the Go
+// resolver's retries actually try different servers instead of re-dialing the
+// same dead one.
+var egressResolverRotation atomic.Uint64
+
+// egressFallbackDnsServers are dialed when the physical link's own resolvers
+// cannot be read. The same operators as DefaultDnsResolverSettings, as plain
+// :53, and the same list as the Windows file's fallback.
+var egressFallbackDnsServers = []string{
+	"1.1.1.1",
+	"9.9.9.9",
+	"8.8.8.8",
+	"208.67.222.222",
+}
+
+func egressResolverDial(ctx context.Context, network string, addr string) (net.Conn, error) {
+	if !egressSelfMarked() {
+		// not providing a tunnel: dial the server the Go resolver chose from
+		// the system configuration, unmarked — the plain platform behavior.
+		// The normal state for every Linux process that is not the tunnel
+		// daemon: this resolver is always handed out, and this branch is what
+		// keeps it behaviourally identical to the platform resolver there.
+		dialer := &net.Dialer{Timeout: egressResolverDialTimeout}
+		return dialer.DialContext(ctx, network, addr)
+	}
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	index4, index6 := egressResolverFamilies()
+	servers := egressDnsServers(index4, index6)
+	if len(servers) == 0 {
+		return nil, fmt.Errorf("egress resolver: no dns servers")
+	}
+	server := servers[int(egressResolverRotation.Add(1)-1)%len(servers)]
+	serverAddr := net.JoinHostPort(server, port)
+	// egressDialer is inert on Linux (applyEgressInterface is a no-op here and
+	// nothing sets an interface index), but it is kept so an embedder that does
+	// set one still gets the bind; egressMarkControl is the mechanism that
+	// actually matters, and egressDialer chains it rather than replacing it.
+	dialer := egressDialer(&net.Dialer{
+		Timeout: egressResolverDialTimeout,
+		Control: egressMarkControl,
+	})
+	conn, err := dialer.DialContext(ctx, network, serverAddr)
+	logControlDialResult(nil, "dns", true, network, serverAddr, conn, err)
+	return conn, err
+}
+
+// egressMarkControl sets SO_MARK on the resolver's socket at creation time,
+// before connect() and therefore before the routing decision — which is the
+// only point at which it can do any good (setting it later triggers
+// ip_route_me_harder, which reuses a source address already taken from the
+// tun; see urnetwork-linux Tunnel.hpp).
+//
+// BELT AND BRACES, DELIBERATELY, AND DELIBERATELY NOT FATAL. Inside the daemon
+// this is redundant: the cgroup-BPF program already stamped the same value on
+// this socket at inet_create(), and setting it again is a no-op with the same
+// result. It is here for the case the BPF path does not cover — a process that
+// steers by mark without being in that cgroup — and because SO_MARK is exactly
+// the "net.Dialer.Control hook the SDK ABI does not export" that forced the
+// client into cgroup-BPF in the first place; inside the SDK we do have it.
+//
+// A failure is swallowed rather than returned. setsockopt(SO_MARK) needs
+// CAP_NET_ADMIN or CAP_NET_RAW even to write the value it already holds, so an
+// unprivileged embedding gets EPERM here — and failing the dial on that would
+// take DNS away from a socket the kernel had already marked correctly. The
+// first failure is logged once, because a silent no-op on this path is the
+// class of bug this whole file exists to undo.
+func egressMarkControl(_ string, _ string, c syscall.RawConn) error {
+	var innerErr error
+	err := c.Control(func(fd uintptr) {
+		innerErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_MARK, egressSocketMark)
+	})
+	if err != nil {
+		return err
+	}
+	if innerErr != nil && egressMarkControlReported.CompareAndSwap(false, true) {
+		loggerOrDefault(nil).Infof(
+			"[egress]so_mark not set on the resolver socket, the cgroup program's mark still stands: %s\n",
+			innerErr,
+		)
+	}
+	return nil
+}
+
+var egressMarkControlReported atomic.Bool
+
+// egressSelfMarkExpiration bounds reuse of the socket-mark probe. The mark
+// appears once, when the client attaches its cgroup program at daemon start,
+// and does not change again for the life of the process; a short reuse window
+// keeps two syscalls off the per-dial path without making that one transition
+// slow to notice.
+const egressSelfMarkExpiration = 3 * time.Second
+
+type egressSelfMarkResult struct {
+	marked  bool
+	expires time.Time
+}
+
+var egressSelfMarkCache atomic.Pointer[egressSelfMarkResult]
+
+// egressSelfMarked reports whether a socket created right now by this process
+// is born carrying egressSocketMark — i.e. whether this process's own traffic
+// is steered around the tunnel it provides. This is the same read-back
+// urnetwork-linux proves its cgroup program with (Tunnel.cpp
+// ReadFreshSocketMark), for the same reason: it measures the kernel's actual
+// behavior for a real socket rather than asserting that an attach succeeded.
+func egressSelfMarked() bool {
+	now := time.Now()
+	if cached := egressSelfMarkCache.Load(); cached != nil && now.Before(cached.expires) {
+		return cached.marked
+	}
+	marked := egressReadFreshSocketMark() == egressSocketMark
+	egressSelfMarkCache.Store(&egressSelfMarkResult{
+		marked:  marked,
+		expires: now.Add(egressSelfMarkExpiration),
+	})
+	return marked
+}
+
+// egressReadFreshSocketMark opens a throwaway datagram socket and reads SO_MARK
+// back off it. Returns 0 when the socket cannot be made or the option cannot be
+// read, which is the same answer as "not marked" and lands on the inert path.
+func egressReadFreshSocketMark() int {
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, unix.IPPROTO_UDP)
+	if err != nil {
+		return 0
+	}
+	defer unix.Close(fd)
+	mark, err := unix.GetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_MARK)
+	if err != nil {
+		return 0
+	}
+	return mark
+}
+
+// egressResolverFamilies reports which address families a substituted server
+// may use, in the (index4, index6) form usableEgressDnsServer takes. On Windows
+// the answer is "the families the interface bind carries"; on Linux the escape
+// is a socket mark, which carries both families, so the answer is "the families
+// this host actually has a usable address for". Anything explicitly set through
+// SetEgressInterfaceIndex still wins, so an embedder that does bind interfaces
+// keeps the Windows meaning.
+//
+// The value is used only as a per-family "is this carried" flag and as the
+// server-list cache key, so picking the first qualifying interface is enough —
+// a roam changes the index and misses the cache, which is the wanted effect.
+func egressResolverFamilies() (uint32, uint32) {
+	index4, index6 := EgressInterfaceIndex()
+	if index4 != 0 || index6 != 0 {
+		return index4, index6
+	}
+	return egressGlobalInterfaceIndexes()
+}
+
+// egressGlobalInterfaceIndexes returns the index of an up, non-loopback
+// interface carrying a global unicast address of each family, or 0 for a family
+// the host has none for. Dialing a family the host cannot carry costs a full
+// egressResolverDialTimeout per candidate before a usable server is reached —
+// the same multi-second control-plane stall the Windows file's link-local rule
+// exists to prevent — so a family with no address is reported as not carried.
+//
+// The tun is excluded for free: urnetwork-linux gives it 169.254.2.1, which is
+// link-local and so not global unicast.
+func egressGlobalInterfaceIndexes() (uint32, uint32) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return 0, 0
+	}
+	var index4 uint32
+	var index6 uint32
+	for _, ifc := range interfaces {
+		if ifc.Flags&net.FlagUp == 0 || ifc.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := ifc.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			ipNet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			addr, ok := netip.AddrFromSlice(ipNet.IP)
+			if !ok {
+				continue
+			}
+			addr = addr.Unmap()
+			if !addr.IsGlobalUnicast() {
+				continue
+			}
+			if addr.Is4() {
+				if index4 == 0 {
+					index4 = uint32(ifc.Index)
+				}
+			} else if index6 == 0 {
+				index6 = uint32(ifc.Index)
+			}
+		}
+		if index4 != 0 && index6 != 0 {
+			break
+		}
+	}
+	return index4, index6
+}
+
+// egressDnsServerExpiration is how long a discovered server list is reused
+// before re-reading the resolver configuration (a DHCP renew or roam can change
+// it; a change of carried families keys the cache miss immediately).
+const egressDnsServerExpiration = 60 * time.Second
+
+type egressDnsServerList struct {
+	index4  uint32
+	index6  uint32
+	servers []string
+	expires time.Time
+}
+
+var egressDnsServerCache atomic.Pointer[egressDnsServerList]
+
+// egressDnsServers returns the resolver IPs control queries should use while
+// this process provides a tunnel: the physical link's own resolvers — the same
+// servers the OS resolver would have used before the tun's `~.` link resolver
+// was pushed in front of them — or the public fallback when none can be read.
+func egressDnsServers(index4 uint32, index6 uint32) []string {
+	now := time.Now()
+	if cached := egressDnsServerCache.Load(); cached != nil &&
+		cached.index4 == index4 && cached.index6 == index6 && now.Before(cached.expires) {
+		return cached.servers
+	}
+	servers, source := egressLinkDnsServers(index4, index6)
+	if len(servers) == 0 {
+		servers = egressFallbackDnsServers
+		source = "fallback"
+	}
+	egressDnsServerCache.Store(&egressDnsServerList{
+		index4:  index4,
+		index6:  index6,
+		servers: servers,
+		expires: now.Add(egressDnsServerExpiration),
+	})
+	// at most one line per egressDnsServerExpiration, and only while this
+	// process provides a tunnel. It names the servers control-plane DNS is
+	// about to ride and where they came from, which is the difference between
+	// "the fix engaged" and "the fix fell through to public resolvers".
+	loggerOrDefault(nil).Infof(
+		"[egress]dns servers %v source=%s if=4:%d/6:%d\n",
+		servers, source, index4, index6,
+	)
+	return servers
+}
+
+// egressResolvConfPaths are the resolver configurations read, in order, to find
+// servers reachable over the physical interface. The FIRST path that yields a
+// usable server wins; the rest are not merged, so a stale or captured file
+// cannot dilute a good one.
+//
+// Order, and why each is where it is:
+//
+//   - NetworkManager's no-stub file names the uplink servers NM itself
+//     configured. It is first because it is the only one guaranteed not to
+//     mention the tun: urnetwork-linux ships 95-urnetwork.conf and a udev rule
+//     that make NM treat urnet0 as unmanaged, so NM never learns its resolver.
+//     (Measured on the owner's machine: `nameserver 192.168.12.1` and the
+//     router's link-local v6, while /run/NetworkManager/resolv.conf beside it
+//     held only the 127.0.0.53 stub.)
+//   - systemd-resolved's uplink file (NOT stub-resolv.conf) names every known
+//     uplink server directly rather than the stub. Once the tun link has a `~.`
+//     resolver this file lists that too, but it is the mask address and
+//     usableEgressDnsServer drops it. This is the source on a machine with
+//     resolved and no NetworkManager.
+//   - NetworkManager's ordinary file, which is the real servers when NM is not
+//     in systemd-resolved mode and the stub (dropped as loopback) when it is.
+//   - /etc/resolv.conf last. On a resolved machine it is the stub and yields
+//     nothing, which is the whole problem; on a machine with neither resolved
+//     nor NM it is the only truth there is.
+//
+// Never the stub, in any of them: usableEgressDnsServer rejects loopback, so
+// 127.0.0.53 and 127.0.0.1 can never be substituted. Never the tun's resolver
+// either: it rejects DefaultDnsUpgradeMaskAddress by name, and that is exactly
+// what urnetwork-linux puts on the tun link
+// (sdk.GetDefaultTunnelDnsAddressIpv4).
+var egressResolvConfPaths = []string{
+	"/run/NetworkManager/no-stub-resolv.conf",
+	"/run/systemd/resolve/resolv.conf",
+	"/run/NetworkManager/resolv.conf",
+	"/etc/resolv.conf",
+}
+
+// egressLinkDnsServers returns the first usable server list among
+// egressResolvConfPaths, and the path it came from.
+//
+// Reading files is the whole mechanism here, and it is deliberate: the Windows
+// side reads the adapter table through GetAdaptersAddresses, and the Linux
+// equivalents — resolvectl, `ip`, resolved's D-Bus API — all mean either
+// shelling out from a daemon or taking a D-Bus dependency into this library.
+// These files are the same information, already written down, readable with no
+// privilege and no child process.
+func egressLinkDnsServers(index4 uint32, index6 uint32) ([]string, string) {
+	for _, path := range egressResolvConfPaths {
+		if servers := egressResolvConfServers(path, index4, index6); 0 < len(servers) {
+			return servers, path
+		}
+	}
+	return nil, ""
+}
+
+// egressResolvConfServers parses the `nameserver` lines of one resolv.conf(5)
+// file and returns those a marked socket can actually use, filtered by the
+// shared usableEgressDnsServer rule. A missing or unreadable file is not an
+// error, it is simply no servers.
+func egressResolvConfServers(path string, index4 uint32, index6 uint32) []string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var servers []string
+	seen := map[string]bool{}
+	for _, line := range strings.Split(string(content), "\n") {
+		if commentIndex := strings.IndexAny(line, "#;"); 0 <= commentIndex {
+			line = line[:commentIndex]
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "nameserver" {
+			continue
+		}
+		// ParseAddr keeps a scope zone ("fe80::1%2", which is how both
+		// resolved and NM write a router's link-local v6 resolver), and
+		// JoinHostPort/Dial carry it through to the socket.
+		addr, err := netip.ParseAddr(fields[1])
+		if err != nil {
+			continue
+		}
+		addr = addr.Unmap()
+		if !usableEgressDnsServer(addr, index4, index6) {
+			continue
+		}
+		s := addr.String()
+		if !seen[s] {
+			seen[s] = true
+			servers = append(servers, s)
+		}
+	}
+	return servers
+}

--- a/egress_resolver_linux_test.go
+++ b/egress_resolver_linux_test.go
@@ -1,0 +1,106 @@
+//go:build linux && !android
+
+package connect
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The Linux half of the egress resolver. The substitution and the socket mark
+// need a tunnel-providing daemon to exercise, but the piece that decides WHICH
+// server gets substituted is a pure function over a resolv.conf(5) file, and
+// getting it wrong is how a "fix" ends up substituting the very stub it exists
+// to escape.
+
+func writeResolvConf(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "resolv.conf")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestEgressResolvConfServers(t *testing.T) {
+	// the systemd-resolved stub: this is what /etc/resolv.conf holds on the
+	// machine the deadlock was measured on, and substituting it would send the
+	// query straight back into the tunnel it is meant to escape
+	stub := writeResolvConf(t, `# managed by systemd-resolved
+nameserver 127.0.0.53
+options edns0 trust-ad
+search lan
+`)
+	if servers := egressResolvConfServers(stub, 2, 2); len(servers) != 0 {
+		t.Fatalf("the resolved stub must never be substituted, got %v", servers)
+	}
+
+	// the uplink file: the physical link's own resolvers, plus the tun's
+	// UpgradeMux mask address once the tunnel has pushed its `~.` link
+	// resolver in front of them. The mask answers nothing off-tunnel.
+	uplink := writeResolvConf(t, `# managed by systemd-resolved
+nameserver `+DefaultDnsUpgradeMaskAddress+`
+nameserver 192.168.12.1
+nameserver 192.168.12.1
+nameserver fe80::1a60:41ff:fe3b:cfd9%2
+search lan
+`)
+	servers := egressResolvConfServers(uplink, 2, 2)
+	want := []string{"192.168.12.1", "fe80::1a60:41ff:fe3b:cfd9%2"}
+	if len(servers) != len(want) {
+		t.Fatalf("got %v want %v", servers, want)
+	}
+	for i, server := range servers {
+		if server != want[i] {
+			t.Fatalf("got %v want %v", servers, want)
+		}
+	}
+
+	// a family the host cannot carry is dropped rather than dialed: reaching a
+	// usable server behind it costs a full dial timeout per candidate
+	if servers := egressResolvConfServers(uplink, 2, 0); len(servers) != 1 || servers[0] != "192.168.12.1" {
+		t.Fatalf("v6 must be dropped with no v6 carried, got %v", servers)
+	}
+
+	// a file that is not there is no servers, not an error
+	if servers := egressResolvConfServers(filepath.Join(t.TempDir(), "absent"), 2, 2); servers != nil {
+		t.Fatalf("a missing file must yield no servers, got %v", servers)
+	}
+}
+
+func TestEgressResolverInertWithoutTheEgressMark(t *testing.T) {
+	// the test process is not the tunnel daemon, so nothing has marked its
+	// sockets and control dials must keep the platform resolver exactly as
+	// they did before this file existed
+	if egressSelfMarked() {
+		t.Skip("this process's sockets carry the egress mark; not a plain host")
+	}
+	SetEgressInterfaceIndex(0, 0)
+	// The resolver IS handed out unconditionally now — gating at handout froze
+	// nil into the primary control dialer, which is built once
+	// (newNormalDialTlsContext) and would then never pick the fix up. What must stay
+	// inert off the daemon is the BEHAVIOUR: egressResolverDial takes its
+	// unmarked branch and dials the server the Go resolver chose, unbound,
+	// exactly as the platform resolver would.
+	if egressResolver() == nil {
+		t.Fatal("the egress resolver must be handed out so the per-dial gate can decide")
+	}
+	if egressAwareResolver(nil) != egressBoundResolver {
+		t.Fatal("control dials must receive the egress-bound resolver")
+	}
+	// a caller-supplied resolver still wins
+	custom := &net.Resolver{}
+	if egressAwareResolver(custom) != custom {
+		t.Fatal("a caller's own resolver must take precedence")
+	}
+	// the unmarked dial path must not substitute a server: it resolves through
+	// whatever the host configured, which is the pre-fix behaviour
+	if servers := egressDnsServers(0, 0); len(servers) == 0 {
+		t.Fatal("egressDnsServers must always yield a fallback list")
+	}
+	if egressBound() {
+		t.Fatal("egressBound must stay false with no forced interface and no egress mark")
+	}
+}

--- a/egress_resolver_other.go
+++ b/egress_resolver_other.go
@@ -1,13 +1,22 @@
-//go:build !windows
+//go:build !windows && (!linux || android)
 
 package connect
 
 import "net"
 
-// Off Windows the OS resolver is already tunnel-aware (macOS network
-// extensions and Android VpnService route the extension's own lookups
-// correctly), so control dials keep the platform resolver: nil means
-// net.Dialer uses net.DefaultResolver, exactly as before.
+// On these platforms self-exclusion IS handled at the OS layer, so control
+// dials keep the platform resolver: nil means net.Dialer uses
+// net.DefaultResolver, exactly as before. macOS network extensions route the
+// extension's own lookups around their tunnel, and Android VpnService does the
+// same for the app's (VpnService.protect / addDisallowedApplication).
+//
+// The build tag excludes Linux by hand because Go sets the `linux` tag for
+// GOOS=android too, and a plain `!linux` would take Android's OS-layer answer
+// away from it. Desktop Linux is the platform where the assumption above
+// actually fails — systemd-resolved answers the daemon's lookups from its own
+// cgroup, unmarked, straight into the tunnel — and it has its own
+// implementation in egress_resolver_linux.go. See that file's header for the
+// deadlock this partition exists to describe.
 func egressResolver() *net.Resolver {
 	return nil
 }

--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -206,6 +206,8 @@ func DefaultMultiClientSettings() *MultiClientSettings {
 		// wait this time before enumerating potential clients again
 		// WindowEnumerateEmptyTimeout: 5 * time.Second,
 		WindowEnumerateErrorTimeout: 1 * time.Second,
+		WindowRateLimitBackoffMin:   5 * time.Second,
+		WindowRateLimitBackoffMax:   2 * time.Minute,
 		// long enough for a slow-but-alive platform API round trip; a hung
 		// API must never wedge the enumerate/expand machinery
 		WindowGeneratorTimeout: 20 * time.Second,
@@ -649,6 +651,26 @@ type MultiClientSettings struct {
 	WindowExpandBlockCount int
 	// WindowEnumerateEmptyTimeout time.Duration
 	WindowEnumerateErrorTimeout time.Duration
+	// WindowRateLimitBackoffMin / Max bound the retry cadence when the platform
+	// answers a window generator call with a RATE LIMIT (429).
+	//
+	// WindowEnumerateErrorTimeout alone is a FIXED 1s retry with no jitter, and
+	// it is applied per expander goroutine. That is a thundering herd by
+	// construction: the window runs one expander per slot it wants to fill, so
+	// the aggregate request rate scales linearly with WindowSizeMin, and once
+	// the platform starts refusing, every expander re-asks every second
+	// forever. Measured on a real client 2026-08-17: 3,726 429s over 39
+	// minutes, climbing 327 -> 672 per minute as more slots entered the failing
+	// loop, against a platform budget of 1000/min. Nothing in the loop backed
+	// off, because classifyWindowFailure already recognised the 429 and the
+	// verdict was recorded for the stall label and then discarded.
+	//
+	// Backoff is exponential from Min to Max, doubling per consecutive rate
+	// limit, and JITTERED — jitter is not decoration here, since dozens of
+	// expanders that all failed at the same instant would otherwise retry in
+	// lockstep no matter how long the delay. Any success resets it.
+	WindowRateLimitBackoffMin time.Duration
+	WindowRateLimitBackoffMax time.Duration
 	// WindowGeneratorTimeout bounds each generator call the window's
 	// enumerate/expand machinery makes (NextDestinations, NewClientArgs,
 	// NewClientArgsForDestination). The generator wraps a platform API that
@@ -8023,6 +8045,12 @@ type multiClientWindow struct {
 	cancel context.CancelFunc
 	log    Logger
 
+	// Consecutive platform rate limits across ALL expanders in this window.
+	// Shared deliberately: the herd is the problem, so the backoff has to be a
+	// property of the window rather than of each goroutine. See
+	// windowRetryDelay.
+	rateLimitStreak atomic.Uint64
+
 	generator                    MultiClientGenerator
 	clientReceivePacketCallback  clientReceivePacketFunction
 	clientReceivePacketsCallback clientReceivePacketsFunction
@@ -8701,14 +8729,17 @@ func (self *multiClientWindow) randomEnumerateClientArgs() {
 			self.log.Infof("[multi]window enumerate error timeout = %s\n", err)
 			// a hung/erroring platform api is the platform-unreachable class
 			// unless the message names auth or rate limiting
-			self.recordEvaluationFailure(windowFailurePlatform, err)
+			class := self.recordEvaluationFailure(windowFailurePlatform, err)
 			select {
 			case <-self.ctx.Done():
 				return
-			case <-time.After(self.settings.WindowEnumerateErrorTimeout):
+			case <-time.After(self.windowRetryDelay(class)):
 			}
 			continue
 		}
+		// The platform answered. Any success clears the rate-limit backoff so
+		// the window returns to its normal cadence once the limit lifts.
+		self.windowRetryReset()
 
 		// unconditional (V0): the platform answered with ZERO candidates. Only
 		// a failure while the window is empty — a full window legitimately
@@ -8762,14 +8793,15 @@ func (self *multiClientWindow) randomEnumerateClientArgs() {
 						// platform api again: the client mint is a platform
 						// round trip, so its timeout is platform-unreachable
 						// (auth/rate refine via the message)
-						self.recordEvaluationFailure(windowFailurePlatform, err)
+						class := self.recordEvaluationFailure(windowFailurePlatform, err)
 						select {
 						case <-self.ctx.Done():
 							return
-						case <-time.After(self.settings.WindowEnumerateErrorTimeout):
+						case <-time.After(self.windowRetryDelay(class)):
 						}
 						continue
 					}
+					self.windowRetryReset()
 
 					args := &multiClientChannelArgs{
 						Destination:                    destination,

--- a/ip_remote_multi_client.go
+++ b/ip_remote_multi_client.go
@@ -138,9 +138,24 @@ func DefaultMultiClientSettings() *MultiClientSettings {
 		WindowSizes: map[WindowType]WindowSizeSettings{
 			// TODO increase `WindowSizeMinP2pOnly` when p2p is deployed
 			WindowTypeQuality: WindowSizeSettings{
-				WindowSizeMin:     2,
-				WindowSizeMax:     6,
-				WindowSizeHardMax: 12,
+				// RAISED 2/6/12 -> 6/12/16. A quality window of 2 has no
+				// redundancy: one bad provider is half the window, and a
+				// second is a total failure with nothing left to fall back
+				// to. Field report on linux: an idle session sat at 2 held /
+				// ~4 probed (EvaluationPoolMultiple=2), both went
+				// unresponsive, and because windowOutcomeAction returns
+				// outcomeNone once failOutcome has latched, the window never
+				// rebuilt for the remaining 22 minutes of the session. A
+				// larger floor does not fix that latch, but it makes a single
+				// bad provider survivable rather than fatal, which is the
+				// point of holding a window at all.
+				//
+				// Cost is real and deliberate: WindowSizeMin is a floor that
+				// holds AT IDLE, so this raises steady-state provider
+				// sessions and the contracts behind them.
+				WindowSizeMin:     6,
+				WindowSizeMax:     12,
+				WindowSizeHardMax: 16,
 				// reconnects per source
 				WindowSizeReconnectScale: 1.2,
 				KeepHealthiestCount:      0,

--- a/ip_remote_multi_client_grid_leak2_test.go
+++ b/ip_remote_multi_client_grid_leak2_test.go
@@ -85,7 +85,11 @@ func TestMultiClientMonitorPairingFlappingProviders(t *testing.T) {
 	live, stuck, maxLive := mirror.sample(settings.PingTimeout + settings.WindowExpandTimeout + settings.StatsWindowMaxUnhealthyDuration + settings.WindowResizeTimeout + removeTimeout + 3*time.Second)
 	fmt.Printf("[leaktest2] final live=%d stuck=%d maxLive=%d totalSeen=%d\n", live, stuck, maxLive, mirror.totalSeen())
 
-	bound := 3 * (12 + 4)
+	// DERIVED from the settings under test rather than copied out of them, for
+	// the same reason as its twin in ip_remote_multi_client_grid_leak_test.go:
+	// this was the identical stale literal `3 * (12 + 4)`.
+	bound := 3 * (settings.WindowSizes[WindowTypeQuality].WindowSizeHardMax +
+		settings.WindowSizes[WindowTypeSpeed].WindowSizeHardMax)
 	if maxLive > bound {
 		t.Errorf("live point set grew beyond bound: maxLive=%d > %d", maxLive, bound)
 	}

--- a/ip_remote_multi_client_grid_leak_test.go
+++ b/ip_remote_multi_client_grid_leak_test.go
@@ -78,10 +78,15 @@ func TestMultiClientMonitorPairingUnableToConnect(t *testing.T) {
 	live, stuck, maxLive := mirror.sample(settings.PingTimeout + settings.WindowExpandTimeout + removeTimeout + 2*time.Second)
 	fmt.Printf("[leaktest] final live=%d stuck=%d maxLive=%d totalSeen=%d\n", live, stuck, maxLive, mirror.totalSeen())
 
-	// the window targets are WindowSizeMin(quality)=2 + min(speed)=1 with hard max
-	// 12+4. a healthy pairing keeps the live set within a small multiple of the
-	// hard max; give slack for in-flight evaluations across both windows.
-	bound := 3 * (12 + 4)
+	// a healthy pairing keeps the live set within a small multiple of the
+	// combined hard max; give slack for in-flight evaluations across both windows.
+	//
+	// DERIVED from the settings under test rather than copied out of them. This
+	// was the literal `3 * (12 + 4)`, the quality and speed WindowSizeHardMax
+	// values at the time it was written, which silently becomes wrong the moment
+	// either default moves.
+	bound := 3 * (settings.WindowSizes[WindowTypeQuality].WindowSizeHardMax +
+		settings.WindowSizes[WindowTypeSpeed].WindowSizeHardMax)
 	if maxLive > bound {
 		t.Errorf("live point set grew beyond bound: maxLive=%d > %d", maxLive, bound)
 	}

--- a/ip_remote_multi_client_outcome.go
+++ b/ip_remote_multi_client_outcome.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"context"
+	mathrand "math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -275,9 +276,63 @@ func (self *multiClientWindow) noteClientAdded(client *multiClientChannel) {
 
 // recordEvaluationFailure counts one classified failure and refreshes the
 // published reason. Called with no locks held.
-func (self *multiClientWindow) recordEvaluationFailure(fallback windowFailureClass, err error) {
-	self.failures.record(classifyWindowFailure(err, fallback), time.Now())
+// Returns the class it recorded. The caller needs it: a rate limit is the one
+// failure whose correct response is to SLOW DOWN, and the verdict used to be
+// computed here, filed for the stall label, and thrown away — so the retry
+// cadence for "the platform is refusing you for asking too often" was the same
+// 1s as for any other error. See WindowRateLimitBackoffMin.
+func (self *multiClientWindow) recordEvaluationFailure(fallback windowFailureClass, err error) windowFailureClass {
+	class := classifyWindowFailure(err, fallback)
+	self.failures.record(class, time.Now())
 	self.publishStallStatus()
+	return class
+}
+
+// windowRetryDelay converts a recorded failure into how long the expander
+// should wait before asking again.
+//
+// Everything except a rate limit keeps the flat WindowEnumerateErrorTimeout.
+// A rate limit doubles from WindowRateLimitBackoffMin toward
+// WindowRateLimitBackoffMax per CONSECUTIVE rate limit, then takes uniform
+// jitter across [delay/2, delay). The counter is shared by every expander in
+// the window and is reset by windowRetryReset on any successful generator
+// call, so a one-off 429 costs one backoff and a genuine storm decays.
+func (self *multiClientWindow) windowRetryDelay(class windowFailureClass) time.Duration {
+	if class != windowFailureRateLimit {
+		return self.settings.WindowEnumerateErrorTimeout
+	}
+	min := self.settings.WindowRateLimitBackoffMin
+	if min <= 0 {
+		min = self.settings.WindowEnumerateErrorTimeout
+	}
+	max := self.settings.WindowRateLimitBackoffMax
+	if max < min {
+		max = min
+	}
+	// Bounded shift: consecutive counts climb without limit during a long
+	// outage, and 1<<64 is not a delay.
+	n := self.rateLimitStreak.Add(1) - 1
+	delay := min
+	for i := uint64(0); i < n && delay < max; i++ {
+		delay *= 2
+	}
+	if delay > max {
+		delay = max
+	}
+	// Jitter DOWNWARD only, so the cap is a real ceiling: dozens of expanders
+	// that failed in the same instant must not retry in lockstep.
+	half := delay / 2
+	if half <= 0 {
+		return delay
+	}
+	return half + time.Duration(mathrand.Int63n(int64(half)))
+}
+
+// windowRetryReset clears the rate-limit streak after a generator call that
+// did NOT fail. Without this the window would stay in a long backoff after the
+// platform recovered.
+func (self *multiClientWindow) windowRetryReset() {
+	self.rateLimitStreak.Store(0)
 }
 
 // stallReason derives the current diagnosis.

--- a/ip_remote_multi_client_ratelimit_test.go
+++ b/ip_remote_multi_client_ratelimit_test.go
@@ -1,0 +1,98 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// The storm this guards against, measured on a real client 2026-08-17: 3,726
+// platform 429s over 39 minutes, climbing 327 -> 672 per minute against a
+// 1000/min budget, because every expander retried on a flat 1s cadence and
+// nothing consulted the rate-limit class that classifyWindowFailure had
+// already computed.
+
+func newRateLimitTestWindow() *multiClientWindow {
+	// windowRetryDelay/windowRetryReset touch only settings and the streak;
+	// recordEvaluationFailure additionally needs the recorder and the monitor
+	// that publishStallStatus reports through.
+	return &multiClientWindow{
+		settings: DefaultMultiClientSettings(),
+		monitor:  NewRemoteUserNatMultiClientMonitorWithDefaults(),
+		clients:  map[Id]*multiClientChannel{},
+		failures: &windowFailureRecorder{},
+	}
+}
+
+func TestWindowRetryDelayNonRateLimitIsUnchanged(t *testing.T) {
+	w := newRateLimitTestWindow()
+	for _, class := range []windowFailureClass{windowFailurePlatform, windowFailureProvider, windowFailureAuth} {
+		if d := w.windowRetryDelay(class); d != w.settings.WindowEnumerateErrorTimeout {
+			t.Fatalf("class %v must keep the flat cadence, got %s", class, d)
+		}
+	}
+}
+
+func TestWindowRetryDelayRateLimitBacksOffAndIsBounded(t *testing.T) {
+	w := newRateLimitTestWindow()
+	min := w.settings.WindowRateLimitBackoffMin
+	max := w.settings.WindowRateLimitBackoffMax
+
+	first := w.windowRetryDelay(windowFailureRateLimit)
+	if first < min/2 || first >= min {
+		t.Fatalf("first backoff must be jittered within [min/2, min), got %s (min %s)", first, min)
+	}
+	// every delay stays under the ceiling no matter how long the outage runs
+	for i := 0; i < 200; i++ {
+		d := w.windowRetryDelay(windowFailureRateLimit)
+		if d >= max {
+			t.Fatalf("backoff exceeded the ceiling at iteration %d: %s >= %s", i, d, max)
+		}
+		if d <= 0 {
+			t.Fatalf("non-positive delay at iteration %d: %s", i, d)
+		}
+	}
+	// and it did grow rather than sitting at the floor
+	if late := w.windowRetryDelay(windowFailureRateLimit); late <= min {
+		t.Fatalf("backoff never grew: %s <= min %s", late, min)
+	}
+}
+
+func TestWindowRetryResetReturnsToTheFloor(t *testing.T) {
+	w := newRateLimitTestWindow()
+	for i := 0; i < 8; i++ {
+		w.windowRetryDelay(windowFailureRateLimit)
+	}
+	w.windowRetryReset()
+	d := w.windowRetryDelay(windowFailureRateLimit)
+	if d >= w.settings.WindowRateLimitBackoffMin {
+		t.Fatalf("after reset the backoff must start from the floor again, got %s", d)
+	}
+}
+
+// Jitter is not decoration: dozens of expanders fail in the same instant, and
+// without it they would retry in lockstep however long the delay.
+func TestWindowRetryDelayIsJittered(t *testing.T) {
+	w := newRateLimitTestWindow()
+	seen := map[time.Duration]bool{}
+	for i := 0; i < 32; i++ {
+		w.windowRetryReset()
+		seen[w.windowRetryDelay(windowFailureRateLimit)] = true
+	}
+	if len(seen) < 8 {
+		t.Fatalf("expected jittered delays, got only %d distinct values in 32 draws", len(seen))
+	}
+}
+
+// The verdict must actually reach the caller — it used to be computed and
+// discarded, which is the whole reason the storm was possible.
+func TestRecordEvaluationFailureReturnsTheRateLimitClass(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w := outcomeTestWindow(ctx, newRecordingLogger())
+	class := w.recordEvaluationFailure(windowFailurePlatform, errors.New("429 Too Many Requests: <html>"))
+	if class != windowFailureRateLimit {
+		t.Fatalf("a 429 must classify as a rate limit, got %v", class)
+	}
+}


### PR DESCRIPTION
Two independent fixes for the Linux client, plus one product change, each in its own commit.

Verified with Go 1.26.6: root package builds for `linux/amd64`, `linux/arm64`, `android/arm64`, `windows/amd64`, `darwin/arm64`; `go vet` clean in the touched files; **full suite green, zero failures**.

---

### 1. Desktop Linux never got the egress-bound resolver (`egress_resolver_linux.go`)

`egress_resolver_windows.go` exists because a tunnel-providing machine's system resolver points into the tunnel it is building. Its own comment names the failure: *"the system configuration ... includes the tun's own mask resolver, the exact dead end this resolver exists to avoid."*

Linux got `egress_resolver_other.go`, which returns `nil` on the stated assumption that *"Off Windows the OS resolver is already tunnel-aware."* That is true of macOS network extensions and Android `VpnService`. **It is false on desktop Linux**, where the client points `systemd-resolved` at the tunnel with a per-link resolver carrying domain `~.`. The daemon's own sockets are fwmark-excluded, but `systemd-resolved` is a separate process in a different cgroup, so its query follows the tun route.

**The deadlock:** provider window empties → daemon needs DNS to reach the platform to fetch new providers → that lookup dies in the empty tunnel → window can never refill. Only a manual disconnect clears it.

Measured on a real client:

| | healthy session | deadlocked |
|---|---|---|
| `transport down: verdicts held` | 30 | 49 |
| `transport restored` | **21** | **0** |

plus 310 × `encryption required: session not established with peer`, while the daemon's *already-established* platform connection stayed healthy and kept creating contracts. One established connection fine, every new name-resolution-dependent connection dead.

After the fix, on the same machine: **72–93% transport recovery across normal use, zero `encryption required`.**

The gate is **inside `Dial`, not at handout** — deliberately, and matching the Windows file. `NetDialer()` is called once for the primary control dialer (`net_http.go` builds a `tls.Dialer` and returns its `DialContext`), so gating at handout froze `nil` into that dialer for the process lifetime and the fix would never engage.

Build tags partition every GOOS exactly once: `windows` / `linux && !android` / `!windows && (!linux || android)`. The android exclusion is required — `GOOS=android` satisfies both the `linux` tag and the `_linux.go` suffix, so a bare `linux` tag defines `egressResolver` twice.

### 2. Rate-limit storm: the code detected 429s and ignored them

`classifyWindowFailure` already recognises `"rate limit"` / `"too many requests"` / `"429"` and returns `windowFailureRateLimit`. `recordEvaluationFailure` computed that verdict, filed it for the stall label, and **discarded it** — so the one failure class whose correct response is *slow down* retried on the same flat `WindowEnumerateErrorTimeout` (1s, no jitter) as every other error, **per expander goroutine**.

Measured: **3,726 platform 429s in 39 minutes, climbing 327 → 672/min** against a 1000/min budget. It stopped only because the window happened to fill.

`recordEvaluationFailure` now returns its class; rate limits back off exponentially (5s → 2m, jittered down) and reset on any success. Non-rate-limit paths are unchanged. Five new tests, including one asserting the verdict actually reaches the caller.

**Not done, disclosed:** `Retry-After` is not honoured — the error reaches this layer as a formatted string, so response headers never get here.

### 3. Quality provider window `2/6/12` → `6/12/16`

A window with `WindowSizeMin: 2` has no redundancy: one bad provider is half of it, two is total failure. Field evidence: an idle session sat at 2 held / ~4 probed, both went unresponsive, and because `windowOutcomeAction` returns `outcomeNone` once `failOutcome` latches, the window never rebuilt for 22 minutes.

A supporting argument from your own newer code: `filterDestinationServiceFailures` early-returns at `len(candidates) <= 1`, so at `WindowSizeMin: 2` it degenerates to a no-op once one exit is marked failed. A floor of 6 gives that feature headroom.

Cost is real and deliberate — `WindowSizeMin` is a floor that holds at idle, so this raises steady-state provider sessions. Ordered last, after the backoff it depends on.

---

**Note:** commits are ordered so each is individually sound; the backoff precedes the window raise for exactly that reason. Happy to split #3 into its own PR if you'd rather take the two bug fixes first.
