### PR TITLE
test: make the source-anchor harness immune to CRLF checkouts

### DIFF
--- a/ip_remote_multi_client_blackhole_test.go
+++ b/ip_remote_multi_client_blackhole_test.go
@@ -1204,17 +1204,28 @@ func TestBlackholeGateUsesLoadScaledDestinations(t *testing.T) {
 	}
 }
 
+// readSource normalizes line endings, because functionBody delimits a body with
+// a bare "\n}\n" and git checks these files out with CRLF wherever core.autocrlf
+// is on, which is the default on Windows. Without this the delimiter matches
+// nothing, functionBody hands back the whole rest of the file, and every anchor
+// built on strings.Contains passes against text from somewhere else entirely.
+// The six anchors written as strings.Count fail loudly in that state; the
+// eighty-odd written as strings.Contains do not, so the failure is silent
+// exactly where the protection matters most.
 func readSource(name string) (string, error) {
 	b, err := os.ReadFile(name)
 	if err != nil {
 		return "", err
 	}
-	return string(b), nil
+	return strings.ReplaceAll(string(b), "\r\n", "\n"), nil
 }
 
 // functionBody returns the source between a function's signature and the
 // closing brace at column 0. Good enough for asserting a call site exists,
-// which is all it is used for.
+// which is all it is used for. A missing terminator reports false rather than
+// returning the rest of the file: an anchor that silently widens to the whole
+// file still passes, and a passing anchor that proves nothing is worse than no
+// anchor, because it is indistinguishable from a real one.
 func functionBody(source string, signature string) (string, bool) {
 	start := strings.Index(source, signature)
 	if start < 0 {
@@ -1224,5 +1235,5 @@ func functionBody(source string, signature string) (string, bool) {
 	if end := strings.Index(rest, "\n}\n"); 0 <= end {
 		return rest[:end], true
 	}
-	return rest, true
+	return "", false
 }


### PR DESCRIPTION
Test-only. No production code.

`readSource()` in `ip_remote_multi_client_blackhole_test.go` reads source files to anchor assertions against real code. On a checkout with CRLF line endings the anchors silently fail to match. Normalising line endings inside `readSource()` repairs every call site at once rather than patching them individually.

Also makes `functionBody()` return `false` when it cannot find the terminator, instead of silently widening to the rest of the file — a miss there previously produced an anchor that matched far more than intended, which is the failure mode most likely to make one of these tests pass for the wrong reason.

## Verification

Run on a branch cut from `main`, not on a fork branch:

- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test -run "TestBlackhole|SourceAnchor" -v .` — **33 PASS, 0 FAIL**

Because the `functionBody` change tightens terminator handling, I also enumerated every test in the root package that calls it — **50 tests across 19 files, 66 call sites** — and ran that explicit set: **50 PASS, 0 FAIL**. No existing anchor relies on the old widening behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)