### PR TITLE
Demote a control-plane address family that fails after connect, plus a force override

### DIFF
--- a/control_family.go
+++ b/control_family.go
@@ -1,0 +1,709 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/wlynxg/anet"
+)
+
+// Address-family policy for this process's CONTROL-PLANE dials: the api
+// https client, the platform control websocket, and the h3/quic transport's
+// name path. The tunnelled user data plane is not affected and is IPv4-only by
+// its own design (see Tun.dialContext).
+//
+// Two independent pieces of state live here. The POLICY is what a developer
+// set and is never changed by anything else. The DEMOTION LEDGER (below) is
+// what this process has learned about a family that connects and then fails.
+// Keeping them apart is what lets the ui round-trip "Auto" as "Auto" while a
+// demotion is quietly in force.
+//
+// Process-global, like the egress interface binding in egress.go, and read
+// INSIDE each dial rather than captured when a dialer is built -- a client
+// strategy memoizes its http client and its tls dialer for the life of the
+// process, so a value read at construction could never be changed at runtime.
+type IpFamilyPolicy int32
+
+const (
+	// Happy Eyeballs as the platform provides it, plus reactive demotion.
+	IpFamilyAuto IpFamilyPolicy = 0
+	// Control dials use IPv4 only, whatever the ledger has learned.
+	IpFamilyForce4 IpFamilyPolicy = 1
+	// Control dials use IPv6 only, whatever the ledger has learned.
+	IpFamilyForce6 IpFamilyPolicy = 2
+)
+
+var controlIpFamilyPolicy atomic.Int32
+
+// SetControlIpFamilyPolicy sets the control-plane family policy for this
+// process. An unrecognised value is Auto rather than an error: this is fed
+// from a persisted file and across a gomobile boundary where an older or
+// newer peer may carry a value this build does not know, and the safe
+// interpretation of "something I do not understand" is "do what you would
+// have done anyway".
+func SetControlIpFamilyPolicy(policy IpFamilyPolicy) {
+	switch policy {
+	case IpFamilyForce4, IpFamilyForce6:
+	default:
+		policy = IpFamilyAuto
+	}
+	controlIpFamilyPolicy.Store(int32(policy))
+}
+
+// ControlIpFamilyPolicy returns the policy alone. It never reflects a learned
+// demotion -- see controlFamilyStatus for that.
+func ControlIpFamilyPolicy() IpFamilyPolicy {
+	return IpFamilyPolicy(controlIpFamilyPolicy.Load())
+}
+
+// controlDialNetwork narrows a family-agnostic network string ("tcp", "udp")
+// to a family-specific one when a policy or a demotion says so, and returns it
+// unchanged otherwise.
+//
+// A FORCE conflicting with an explicitly requested family is an error, which
+// preserves the semantics the dead DisableIpv4/DisableIpv6 pair had: a caller
+// that asked for tcp6 by name must not silently be given tcp4. A DEMOTION
+// never errors -- it is a heuristic, and a heuristic must not fail a caller's
+// explicit request.
+//
+// `addr` is the dial target, and is load bearing: see the literal check below.
+func controlDialNetwork(network string, addr string) (string, error) {
+	// An address that is ALREADY AN IP LITERAL has no family choice left in
+	// it. There is no resolution step to steer, so narrowing cannot change
+	// which family is dialed -- it can only turn a dial that would have worked
+	// into an instant "no suitable address found", which is what
+	// `dial tcp6 1.1.1.1:443` returns.
+	//
+	// That is not a corner case, it is the whole fallback layer: the extender
+	// dialers dial extenderConfig.Ip (net_extender.go), and the remote plain
+	// DNS resolver dials a configured resolver address (net_http_doh.go). A
+	// demotion learned on the api path used to take both of them down with it,
+	// and every one of those failures is a CONNECT failure, so none of them
+	// recorded anything that could undo the demotion.
+	if isIPLiteralDialAddr(addr) {
+		return network, nil
+	}
+
+	policy := ControlIpFamilyPolicy()
+
+	switch network {
+	case "tcp4", "udp4":
+		if policy == IpFamilyForce6 {
+			return "", fmt.Errorf("ipv4 is disabled by the control family policy")
+		}
+		return network, nil
+	case "tcp6", "udp6":
+		if policy == IpFamilyForce4 {
+			return "", fmt.Errorf("ipv6 is disabled by the control family policy")
+		}
+		return network, nil
+	case "tcp", "udp":
+		// narrowed below
+	default:
+		// unix sockets and anything else are not ours to reinterpret
+		return network, nil
+	}
+
+	switch policy {
+	case IpFamilyForce4:
+		return network + "4", nil
+	case IpFamilyForce6:
+		return network + "6", nil
+	}
+	// auto: a live demotion narrows to the family that is not demoted
+	switch controlFamilyDemotedFamily() {
+	case 6:
+		return network + "4", nil
+	case 4:
+		return network + "6", nil
+	}
+	return network, nil
+}
+
+// isIPLiteralDialAddr reports whether a dial target names an address rather
+// than a host. Accepts a bare literal as well as host:port, because callers
+// reach ConnectSettings.DialContext with both shapes.
+func isIPLiteralDialAddr(addr string) bool {
+	if addr == "" {
+		return false
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	return net.ParseIP(host) != nil
+}
+
+const (
+	// A demotion has to outlast the reconnect storm that follows a failure,
+	// and a persistent path problem has to stop costing the user anything
+	// within a couple of strikes. Five minutes doubling to six hours does
+	// both: the second strike already covers a ten-minute session, and a
+	// genuinely broken tunnel settles at the cap.
+	controlFamilyDemotionBase = 5 * time.Minute
+	controlFamilyDemotionMax  = 6 * time.Hour
+)
+
+type controlFamilyDemotion struct {
+	until   time.Time
+	strikes int
+}
+
+// the learned half of the policy. Guarded by its own mutex rather than folded
+// into an atomic: an entry is three fields and every read is off the hot path
+// of an already-blocking dial.
+var controlFamilyLedger = struct {
+	mu      sync.Mutex
+	demoted map[int]controlFamilyDemotion
+	now     func() time.Time
+	probe   func(family int) bool
+}{
+	demoted: map[int]controlFamilyDemotion{},
+	now:     time.Now,
+	probe:   probeFamilySupport,
+}
+
+func init() {
+	// a path change invalidates everything learned about the old path
+	AddNetworkChangeListener(controlFamilyClear)
+}
+
+// controlFamilyDemote records that `family` connected and then failed. It
+// reports whether the demotion took.
+//
+// It is REFUSED when the other family is not usable on this device. On an
+// IPv6-only network with no CLAT there is no IPv4 to fall back to, and
+// demoting IPv6 there would take the user from a slow control plane to no
+// control plane at all.
+func controlFamilyDemote(family int) bool {
+	// The developer setting and the learned memory are independent state and
+	// must never mix, and this is where they would. Under a force
+	// there is no other family in play: a timeout on the only family the
+	// policy permits is not evidence about family CHOICE, because there is
+	// nothing to compare it against, and the retry it would trigger dials
+	// straight into controlDialNetwork's own force-conflict error.
+	//
+	// The damage lands later. A strike written under Force IPv4 makes the
+	// status line read "IPv4 demoted" beside a policy row reading Force IPv4,
+	// and it stays armed for the moment the developer sets the row back to
+	// Auto -- at which point Auto steers every control dial, every extender
+	// and the h3/quic pick onto the family they had just forced away from, for
+	// five minutes and up to six hours if strikes accumulated while the force
+	// was on.
+	if ControlIpFamilyPolicy() != IpFamilyAuto {
+		return false
+	}
+
+	other := 4
+	if family == 4 {
+		other = 6
+	}
+
+	controlFamilyLedger.mu.Lock()
+
+	if !controlFamilyLedger.probe(other) {
+		controlFamilyLedger.mu.Unlock()
+		return false
+	}
+
+	now := controlFamilyLedger.now()
+	entry := controlFamilyLedger.demoted[family]
+	entry.strikes += 1
+	backoff := controlFamilyDemotionBase << (entry.strikes - 1)
+	if backoff > controlFamilyDemotionMax || backoff <= 0 {
+		backoff = controlFamilyDemotionMax
+	}
+	entry.until = now.Add(backoff)
+	controlFamilyLedger.demoted[family] = entry
+	strikes := entry.strikes
+	controlFamilyLedger.mu.Unlock()
+
+	loggerOrDefault(nil).Infof(
+		"[family]demote family=%d strikes=%d for=%s\n", family, strikes, backoff)
+	return true
+}
+
+// controlFamilyUndemote drops any demotion of `family`, strike count included,
+// and reports whether there was one.
+//
+// The ledger records evidence, and evidence can be contradicted. Two things
+// contradict it, both of them dial failures the ledger would otherwise never
+// hear about: the family we demoted ONTO failing to connect at all, and the
+// in-place retry over that family failing too. The second is not a family
+// problem -- a failure over BOTH families says the moment is bad, not the
+// family -- and the first is the only route back from a demotion that took
+// the user offline, because a connect failure never reaches the strike path.
+//
+// The entry is removed rather than decremented. The backoff exists to stop a
+// CONFIRMED bad path from costing the user repeatedly; a demotion the evidence
+// no longer supports should not leave a doubled sentence behind for the next
+// one.
+func controlFamilyUndemote(family int) bool {
+	controlFamilyLedger.mu.Lock()
+	_, had := controlFamilyLedger.demoted[family]
+	delete(controlFamilyLedger.demoted, family)
+	controlFamilyLedger.mu.Unlock()
+
+	if had {
+		loggerOrDefault(nil).Infof("[family]undemote family=%d (contradicted)\n", family)
+	}
+	return had
+}
+
+// controlFamilyClear drops everything learned. Wired to NetworkChanged.
+func controlFamilyClear() {
+	controlFamilyLedger.mu.Lock()
+	hadEntries := 0 < len(controlFamilyLedger.demoted)
+	clear(controlFamilyLedger.demoted)
+	controlFamilyLedger.mu.Unlock()
+
+	if hadEntries {
+		loggerOrDefault(nil).Infof("[family]clear (network changed)\n")
+	}
+}
+
+// controlFamilyDemotedFamily returns the family currently demoted, or 0.
+// A demotion of BOTH families is impossible by construction -- demoting one
+// requires the other to be usable -- but if it somehow occurred, neither is
+// reported, because narrowing to a family we also believe is broken is worse
+// than letting the platform race them.
+func controlFamilyDemotedFamily() int {
+	family, _, _ := controlFamilyLiveDemotion()
+	return family
+}
+
+// controlFamilyLiveDemotion returns the family currently demoted, its entry,
+// and the clock reading both were judged against.
+//
+// The self-inflicted-outage guard is RE-EVALUATED here, on every read, and not
+// only when the demotion was recorded. A demotion that was safe on the path it
+// was learned on is not necessarily safe on the next one, and the ledger's only
+// invalidation does not reach every process that keeps one:
+// connect.NetworkChanged() has exactly one caller in the tree, DeviceLocal, so
+// on ios the listener fires in the network extension and never in the APP
+// process -- which is the process that dials pre-login and whenever the tunnel
+// is down, the two regimes in the design's own table where a user is most
+// likely to be stuck. Android registers its callbacks from initDevice, so it is
+// exposed the same way while signed out.
+//
+// Checking on use rather than only on record closes that on every platform at
+// once, without needing the host to tell us anything, and it is strictly
+// stronger than a new invalidation signal would be: a demotion can never be
+// APPLIED on a path where RECORDING it would have been refused. It costs a
+// probe only while a demotion is live -- the rare case, and one where the
+// client is already on a degraded path.
+//
+// An entry that fails the check is dropped rather than merely ignored, so the
+// status line the developer ui reads agrees with what the dialer does, and so a
+// path that stays broken is not re-probed on every dial.
+func controlFamilyLiveDemotion() (int, controlFamilyDemotion, time.Time) {
+	controlFamilyLedger.mu.Lock()
+	now := controlFamilyLedger.now()
+
+	live := 0
+	var entry controlFamilyDemotion
+	for family, candidate := range controlFamilyLedger.demoted {
+		if !now.Before(candidate.until) {
+			continue
+		}
+		if live != 0 {
+			controlFamilyLedger.mu.Unlock()
+			return 0, controlFamilyDemotion{}, now
+		}
+		live, entry = family, candidate
+	}
+	if live == 0 {
+		controlFamilyLedger.mu.Unlock()
+		return 0, controlFamilyDemotion{}, now
+	}
+
+	other := 4
+	if live == 4 {
+		other = 6
+	}
+	if controlFamilyLedger.probe(other) {
+		controlFamilyLedger.mu.Unlock()
+		return live, entry, now
+	}
+	delete(controlFamilyLedger.demoted, live)
+	controlFamilyLedger.mu.Unlock()
+
+	loggerOrDefault(nil).Infof(
+		"[family]undemote family=%d (ipv%d is not usable on this path)\n", live, other)
+	return 0, controlFamilyDemotion{}, now
+}
+
+// controlFamilyDemotedUntil is the raw expiry recorded for a family, zero when
+// none is. Unlike controlFamilyLiveDemotion it applies no guard and no expiry
+// check -- it reports what was written. Exists for the tests.
+func controlFamilyDemotedUntil(family int) time.Time {
+	controlFamilyLedger.mu.Lock()
+	defer controlFamilyLedger.mu.Unlock()
+	return controlFamilyLedger.demoted[family].until
+}
+
+// controlFamilyStatus describes any live demotion for the developer ui, and is
+// empty when there is none. The ui shows this BESIDE the policy, never in
+// place of it: a row that read "Force IPv4" because the heuristic fired could
+// not be set back to Auto.
+func controlFamilyStatus() string {
+	// the same read the dialer takes, so the row cannot report a demotion that
+	// is no longer being acted on
+	family, entry, now := controlFamilyLiveDemotion()
+	if family == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"IPv%d demoted for %s (%d strikes)",
+		family,
+		entry.until.Sub(now).Round(time.Minute),
+		entry.strikes,
+	)
+}
+
+// controlFamilyInterface is one interface as the probe needs to see it: a
+// name, its flags, and its addresses. net.Interface plus the result of its
+// Addrs() call, so the probe's decision can be exercised against a synthetic
+// device rather than against whatever the build machine happens to have.
+type controlFamilyInterface struct {
+	name  string
+	flags net.Flags
+	addrs []net.Addr
+}
+
+// hostControlFamilyInterfaces enumerates this device's interfaces. An error
+// from either half is returned rather than swallowed -- the probe fails
+// CLOSED, and it can only do that if it is told enumeration failed.
+//
+// anet, not net. Android 11 restricted the netlink socket that Go's
+// net.Interfaces() uses, so it returns an error there, and this repo already
+// depends on wlynxg/anet for exactly that and already primes it
+// (transport_p2p_webrtc_android.go calls anet.SetAndroidVersion). Off android
+// anet.Interfaces is literally net.Interfaces. It matters more now than it
+// would have before: a probe that fails closed on an enumeration error would
+// otherwise refuse every demotion on modern android, disabling the feature on
+// one of the two platforms it exists for.
+func hostControlFamilyInterfaces() ([]controlFamilyInterface, error) {
+	ifaces, err := anet.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	probed := make([]controlFamilyInterface, 0, len(ifaces))
+	for _, iface := range ifaces {
+		// A per-interface Addrs() error is not fatal: an interface can go away
+		// between the enumeration and the read. It contributes no evidence,
+		// which leaves the probe short of a reason to say yes -- the safe
+		// direction.
+		addrs, err := anet.InterfaceAddrsByInterface(&iface)
+		if err != nil {
+			continue
+		}
+		probed = append(probed, controlFamilyInterface{
+			name:  iface.Name,
+			flags: iface.Flags,
+			addrs: addrs,
+		})
+	}
+	return probed, nil
+}
+
+// the enumeration seam, separate from the ledger's mutex because
+// probeFamilySupport runs while the ledger is held.
+var controlFamilyProbeSource = struct {
+	mu         sync.Mutex
+	interfaces func() ([]controlFamilyInterface, error)
+}{
+	interfaces: hostControlFamilyInterfaces,
+}
+
+// controlFamilyTunnelInterfacePrefixes are the interface names a tunnel takes
+// on the platforms this ships to: utunN on darwin/ios, tunN/tapN on
+// linux/android, plus the ipsec/ppp/wg shapes another vpn on the device may
+// present. Matching by NAME rather than by address range is deliberate:
+// RandomLocalIpv4 (tun.go) hands the tun a 10.a.b.h address chosen precisely
+// so it does NOT overlap any real local subnet, so it is indistinguishable
+// from an ordinary home-lan lease by range alone. Matching by the
+// FlagPointToPoint bit is not an option either -- cellular interfaces carry it
+// on android, and excluding the one real path would be worse than useless.
+var controlFamilyTunnelInterfacePrefixes = []string{
+	"utun", "tun", "tap", "ipsec", "ppp", "wg",
+}
+
+// controlFamilyReservedPrefixes are ranges no working path can be numbered
+// from, and which this project's own tunnels DO use: 192.0.2.0/24 is
+// android's escape-mode tun address (MainService.ESCAPE_FALLBACK_ADDRESS).
+// They pass IsGlobalUnicast, so without this they would read as connectivity.
+var controlFamilyReservedPrefixes = []*net.IPNet{
+	{IP: net.IPv4(192, 0, 2, 0), Mask: net.CIDRMask(24, 32)},    // TEST-NET-1
+	{IP: net.IPv4(198, 51, 100, 0), Mask: net.CIDRMask(24, 32)}, // TEST-NET-2
+	{IP: net.IPv4(203, 0, 113, 0), Mask: net.CIDRMask(24, 32)},  // TEST-NET-3
+	{IP: net.ParseIP("2001:db8::"), Mask: net.CIDRMask(32, 128)},
+}
+
+// probeFamilySupport reports whether this device has a usable path of the
+// family THAT IS NOT THIS PRODUCT'S OWN TUNNEL.
+//
+// The distinction is the whole guard. The app's tun carries a global-unicast
+// IPv4 address by default -- RandomLocalIpv4's 10.a.b.h (tun.go), or
+// 192.0.2.1 in android's escape mode -- and net.IP.IsGlobalUnicast is true for
+// both. An "is there any IsGlobalUnicast IPv4 address" probe therefore answers
+// YES on an IPv6-only iphone with the tunnel up (ios has no CLAT; NAT64/DNS64
+// is the App Store-required configuration), which is exactly the device where
+// demoting IPv6 takes the control plane offline for five minutes and then for
+// up to six hours. The tunnel is not a path to the api: this process's own
+// traffic is excluded from it.
+//
+// NOT nettest.SupportsIPv4/SupportsIPv6: those memoize inside x/net behind a
+// sync.Once, so they answer for whatever network the process started on and
+// never re-evaluate across a wifi/cellular switch. A stale "yes, IPv4 works"
+// is exactly the wrong answer for the guard that keeps a demotion from taking
+// an IPv6-only user offline.
+//
+// FAILS CLOSED. An unreadable interface table means "no evidence", and the
+// only job this function has is to REFUSE a dangerous demotion. A refused
+// demotion costs a user a slow path; a wrongly permitted one costs them the
+// whole control plane.
+func probeFamilySupport(family int) bool {
+	controlFamilyProbeSource.mu.Lock()
+	enumerate := controlFamilyProbeSource.interfaces
+	controlFamilyProbeSource.mu.Unlock()
+
+	ifaces, err := enumerate()
+	if err != nil {
+		return false
+	}
+	for _, iface := range ifaces {
+		if iface.flags&net.FlagUp == 0 {
+			continue
+		}
+		if iface.flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if isControlFamilyTunnelInterface(iface.name) {
+			continue
+		}
+		for _, addr := range iface.addrs {
+			ip := controlFamilyAddrIP(addr)
+			if ip == nil || !ip.IsGlobalUnicast() {
+				continue
+			}
+			if isControlFamilyReservedIP(ip) {
+				continue
+			}
+			if (ip.To4() != nil) == (family == 4) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func controlFamilyAddrIP(addr net.Addr) net.IP {
+	switch v := addr.(type) {
+	case *net.IPNet:
+		return v.IP
+	case *net.IPAddr:
+		return v.IP
+	}
+	return nil
+}
+
+func isControlFamilyTunnelInterface(name string) bool {
+	for _, prefix := range controlFamilyTunnelInterfacePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isControlFamilyReservedIP(ip net.IP) bool {
+	for _, reserved := range controlFamilyReservedPrefixes {
+		if reserved.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// controlDialFamilyLine formats the per-dial family evidence.
+//
+// `family=4` / `family=6` is a LITERAL token, deliberately not derived from an
+// address in the rendered line. The sdk's log redactor rewrites both IPv4 and
+// IPv6 literals to the same opaque <addr:hex> shape, including the brackets
+// that would otherwise give an IPv6 address away -- so in a REDACTED bundle,
+// which is the mode a user is asked to send, an address cannot tell a support
+// engineer which family was dialed. This token can.
+func controlDialFamilyLine(
+	tag string,
+	network string,
+	addr string,
+	conn net.Conn,
+	err error,
+) string {
+	family := "?"
+	if f := connFamily(conn); f != 0 {
+		family = fmt.Sprintf("%d", f)
+	}
+	policy := "auto"
+	switch ControlIpFamilyPolicy() {
+	case IpFamilyForce4:
+		policy = "force4"
+	case IpFamilyForce6:
+		policy = "force6"
+	}
+	demoted := controlFamilyStatus()
+	if demoted == "" {
+		demoted = "none"
+	}
+	if err != nil {
+		return fmt.Sprintf(
+			"[family]dial tag=%s net=%s family=%s policy=%s demoted=%s err=%s",
+			tag, network, family, policy, demoted, err)
+	}
+	return fmt.Sprintf(
+		"[family]dial tag=%s net=%s family=%s policy=%s demoted=%s",
+		tag, network, family, policy, demoted)
+}
+
+// isPathTimeout reports whether err is the post-connect timeout that proves a
+// path is blackholed.
+//
+// Deliberately narrow. A certificate failure, an ALPN mismatch, a refusal or a
+// reset all mean the packets ARRIVED and something at the far end objected --
+// which says nothing about the family. Demoting on those would blame IPv6 for
+// a server misconfiguration and steer every user off a healthy path, which is
+// worse than the bug this exists to fix.
+func isPathTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}
+
+// connFamily is 4, 6, or 0 when the connection has no usable remote address.
+func connFamily(conn net.Conn) int {
+	if conn == nil {
+		return 0
+	}
+	addr := conn.RemoteAddr()
+	if addr == nil {
+		return 0
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		host = addr.String()
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return 0
+	}
+	if ip.To4() != nil {
+		return 4
+	}
+	return 6
+}
+
+// test seams. Package-private and restored by the caller.
+func swapControlFamilyClock(now func() time.Time) func() {
+	controlFamilyLedger.mu.Lock()
+	defer controlFamilyLedger.mu.Unlock()
+	prev := controlFamilyLedger.now
+	controlFamilyLedger.now = now
+	return func() {
+		controlFamilyLedger.mu.Lock()
+		defer controlFamilyLedger.mu.Unlock()
+		controlFamilyLedger.now = prev
+	}
+}
+
+// pickControlIPAddr chooses which resolved address a single-address control
+// dial should use, honoring a force and then a demotion.
+//
+// Falls back to the first address when nothing matches the preference: a
+// forced family the name does not publish must degrade to "dial what exists"
+// rather than make the transport unusable.
+func pickControlIPAddr(addrs []net.IPAddr) net.IPAddr {
+	if len(addrs) == 0 {
+		return net.IPAddr{}
+	}
+	want := 0
+	switch ControlIpFamilyPolicy() {
+	case IpFamilyForce4:
+		want = 4
+	case IpFamilyForce6:
+		want = 6
+	default:
+		switch controlFamilyDemotedFamily() {
+		case 6:
+			want = 4
+		case 4:
+			want = 6
+		}
+	}
+	if want == 0 {
+		// No preference in force: keep net.ResolveUDPAddr's own tie-break
+		// (addrs.first(isIPv4), GOROOT/src/net/ipsock.go) rather than letting
+		// the resolver's own ordering -- normally IPv6-first per RFC 6724 on a
+		// dual-stack, v6-capable device -- become the de facto default. Force
+		// and demotion above are the only things allowed to move off IPv4.
+		for _, addr := range addrs {
+			if addr.IP.To4() != nil {
+				return addr
+			}
+		}
+		return addrs[0]
+	}
+	for _, addr := range addrs {
+		if (addr.IP.To4() != nil) == (want == 4) {
+			return addr
+		}
+	}
+	return addrs[0]
+}
+
+// ControlFamilyStatus describes any live demotion, and is empty when there is
+// none. For a developer ui that shows what auto has learned.
+func ControlFamilyStatus() string {
+	return controlFamilyStatus()
+}
+
+func swapControlFamilyInterfaces(
+	interfaces func() ([]controlFamilyInterface, error),
+) func() {
+	controlFamilyProbeSource.mu.Lock()
+	defer controlFamilyProbeSource.mu.Unlock()
+	prev := controlFamilyProbeSource.interfaces
+	controlFamilyProbeSource.interfaces = interfaces
+	return func() {
+		controlFamilyProbeSource.mu.Lock()
+		defer controlFamilyProbeSource.mu.Unlock()
+		controlFamilyProbeSource.interfaces = prev
+	}
+}
+
+func swapControlFamilyProbe(probe func(family int) bool) func() {
+	controlFamilyLedger.mu.Lock()
+	defer controlFamilyLedger.mu.Unlock()
+	prev := controlFamilyLedger.probe
+	controlFamilyLedger.probe = probe
+	return func() {
+		controlFamilyLedger.mu.Lock()
+		defer controlFamilyLedger.mu.Unlock()
+		controlFamilyLedger.probe = prev
+	}
+}

--- a/control_family_dial.go
+++ b/control_family_dial.go
@@ -1,0 +1,246 @@
+package connect
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// dialControlTlsWithFamilyFallback performs a control-plane dial and its
+// handshake, and retries ONCE over the other address family when the handshake
+// fails with a timeout of its own after the connect succeeded.
+//
+// That sequence -- connect succeeds, handshake times out -- is the signature of
+// a path that carries small packets and drops large ones, which is what a
+// tunnel with a reduced MTU and filtered ICMP Packet-Too-Big does. Happy
+// Eyeballs cannot see it: it races only the tcp handshake, so the broken family
+// WINS the race and then stalls.
+//
+// A timeout that arrives with the caller's own budget already spent is NOT
+// counted: that is a request running out of time, which says nothing about
+// the family, and there would be no time to retry either way. What remains to
+// trigger a demotion is a handshake that hits its OWN timeout while the caller
+// still has budget left, which is also the only case where a retry has
+// anywhere to run.
+//
+// WHAT THAT OWN TIMEOUT IS, and why it is not TlsTimeout. Both production
+// entry points hand this helper a caller deadline at or below TlsTimeout:
+// http.Client.Timeout is RequestTimeout (15s, and it starts before the dial
+// does) on the api path, and gorilla/websocket caps its dial context at
+// Dialer.HandshakeTimeout (5s) on the platform control websocket. A handshake
+// bounded only by TlsTimeout therefore never reaches its own timeout -- the
+// caller's deadline always arrives first, the branch above declines the
+// strike, and the retry never runs at all.
+//
+// So the first handshake is bounded by ControlFamilyFirstHandshakeTimeout, and
+// THAT is the timeout a stalled handshake hits. It is a floor, not a fraction:
+// an earlier version halved whatever the caller had left, which shortens the
+// tls handshake tolerance this product deliberately does not shorten -- doing
+// so risks false-positive demotion for users on genuinely slow links -- and
+// did it hardest exactly where the budget was smallest -- 2.5s on the control
+// websocket, which a congested mobile link reaches with a pinned P-384 chain
+// and nothing wrong. A fixed 8s cannot scale down like that, and it is larger
+// than the entire budget in which a shipping platform websocket dial already
+// completes a connect, this handshake and an http upgrade.
+//
+// THE BOUND IS APPLIED ONLY WHERE TWO ATTEMPTS FIT: the caller must still have
+// ControlFamilyFirstHandshakeTimeout + ControlFamilyRetryReserve left when the
+// handshake starts. A bound that produces a timeout with no room to retry is
+// strictly worse than no bound -- it converts a request that would have kept
+// waiting into one that fails early and learns nothing. Below that threshold
+// the first handshake keeps the caller's whole remaining budget and this
+// helper behaves exactly as it did before the bound existed.
+//
+// That threshold is what decides, per attempt, whether this helper bounds
+// anything. An api attempt that arrives with the whole RequestTimeout (~15s)
+// is bounded -- which is every attempt the client strategy runs in parallel,
+// including the parallel hello a strategy with no successful dialer yet falls
+// straight through to, so a cold launch is bounded. The strategy's SERIAL
+// attempts are not: parallelEval and serialEval give each remembered dialer an
+// equal share of what is left (preferredEvalAttemptContext, net_http.go), and
+// a share of 15s is under 8s + 5s, so the same "no room for two attempts"
+// rule declines to bound them. Nor is the platform control websocket, which
+// gorilla caps at HandshakeTimeout (5s).
+//
+// None of those paths needs a retry of its own: the demotion ledger is
+// process-global (control_family.go), read inside every dial through
+// controlDialNetwork and pickControlIPAddr, so a demotion learned on any
+// bounded attempt is already in force for the control websocket, the h3/quic
+// name path and the extenders. One attempt with enough budget is enough to
+// LEARN; every path benefits. Raising the websocket's HandshakeTimeout
+// instead would change a shared transport timeout for every user to buy a
+// second attempt on a path that already inherits the answer.
+//
+// Exactly one retry, and only to the other family. The caller already sits
+// inside the client strategy's serial and parallel dialer evaluation under a
+// shared request budget, so a helper that retried repeatedly could consume the
+// whole budget alone and starve the other dialers -- which is the failure this
+// exists to prevent, not to reproduce. A second failure over the second family
+// is also not a family problem, and the original error is returned unwrapped.
+func dialControlTlsWithFamilyFallback(
+	ctx context.Context,
+	settings *ConnectSettings,
+	network string,
+	addr string,
+	dial DialContextFunction,
+	handshake func(ctx context.Context, conn net.Conn) (net.Conn, error),
+) (net.Conn, error) {
+	conn, err := dial(ctx, network, addr)
+	if err != nil {
+		conn, err = redialWithoutAContradictedDemotion(ctx, network, addr, dial, err)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// BEFORE the handshake, and before any Close: a closed net.TCPConn is not
+	// required to keep answering RemoteAddr, and the family of the connection
+	// we are about to lose is the whole point of the exercise.
+	failed := connFamily(conn)
+
+	// The bound goes on the handshake and NOT on the connect. The connect has
+	// its own budget (ConnectTimeout) and its own second chance
+	// (redialWithoutAContradictedDemotion, below), which a shortened context
+	// would leave with a dead deadline to dial on. Measuring what is left here
+	// rather than before the dial is also the honest reading: it is the budget
+	// the retry will actually inherit.
+	handshakeCtx, handshakeCancel := firstHandshakeContext(ctx, settings)
+	tlsConn, err := handshake(handshakeCtx, conn)
+	handshakeCancel()
+	if err == nil {
+		return tlsConn, nil
+	}
+	conn.Close()
+
+	// only a family-agnostic dial has somewhere else to go
+	if network != "tcp" && network != "udp" {
+		return nil, err
+	}
+	// an IP literal fixes its own family. There is no other family to retry
+	// onto -- `dial tcp6 1.1.1.1:443` is "no suitable address found" -- and no
+	// name resolution whose family choice a strike could inform.
+	// controlDialNetwork leaves those dials alone for the same reason.
+	if isIPLiteralDialAddr(addr) {
+		return nil, err
+	}
+	if !isPathTimeout(err) {
+		return nil, err
+	}
+	if failed == 0 {
+		return nil, err
+	}
+	// the timeout has to be the handshake's own -- the bound above, or
+	// TlsTimeout when there was no room to apply one. The CALLER's context is
+	// what is tested, never the bounded one: a caller whose budget is gone
+	// gets no strike and no retry, because the strike records what this helper
+	// is about to test and it cannot test anything with no time left.
+	if ctx.Err() != nil {
+		return nil, err
+	}
+	if !controlFamilyDemote(failed) {
+		// refused: the other family is not usable on this device, so there is
+		// nothing to retry onto
+		return nil, err
+	}
+
+	retryNetwork := network + "4"
+	if failed == 4 {
+		retryNetwork = network + "6"
+	}
+	retryConn, retryErr := dial(ctx, retryNetwork, addr)
+	if retryErr != nil {
+		// The other family could not even connect, so the evidence does not
+		// say "this family is blackholed", it says "this moment is bad": a
+		// second failure over the second family is not a family problem.
+		// Leaving the strike standing would narrow every control dial in the
+		// process onto a family that just failed outright.
+		controlFamilyUndemote(failed)
+		return nil, err
+	}
+	retryTlsConn, retryErr := handshake(ctx, retryConn)
+	if retryErr != nil {
+		retryConn.Close()
+		controlFamilyUndemote(failed)
+		return nil, err
+	}
+	return retryTlsConn, nil
+}
+
+// firstHandshakeContext bounds the first handshake of a control dial to
+// ControlFamilyFirstHandshakeTimeout, so that a retry over the other family
+// fits inside the caller's own budget -- and returns the caller's context
+// unchanged when it does not fit.
+//
+// A context with NO deadline is bounded: an unbounded caller has room for two
+// attempts by definition, and leaving it unbounded is the one shape where a
+// stalled handshake would hang until the kernel gave up, which is minutes.
+func firstHandshakeContext(
+	ctx context.Context,
+	settings *ConnectSettings,
+) (context.Context, context.CancelFunc) {
+	noBound := func() (context.Context, context.CancelFunc) {
+		return ctx, func() {}
+	}
+	if settings == nil {
+		return noBound()
+	}
+	bound := settings.ControlFamilyFirstHandshakeTimeout
+	reserve := settings.ControlFamilyRetryReserve
+	if bound <= 0 || reserve <= 0 {
+		return noBound()
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		if time.Until(deadline) < bound+reserve {
+			return noBound()
+		}
+	}
+	return context.WithTimeout(ctx, bound)
+}
+
+// redialWithoutAContradictedDemotion is the only route back from a demotion
+// that took the user offline.
+//
+// The ledger is only ever WRITTEN after a connect succeeded and a handshake
+// then timed out, so a demotion can be confirmed but never refuted: when the
+// family we demoted ONTO cannot connect at all, the dial fails at the connect
+// step and the ledger never hears about it. Until the entry expires -- five
+// minutes, doubling to a six hour cap -- every control dial in the process
+// keeps being steered onto the family that just proved it does not work.
+//
+// A connect failure over a network a live demotion was narrowing is exactly
+// that refutation. It clears the entry and dials once more with the caller's
+// original family-agnostic network, which also restores the Happy Eyeballs
+// race that the narrowing had switched off -- the platform's own answer to a
+// PRE-connect blackhole, which already works.
+//
+// A FORCE is never undone here. It is an explicit developer override whose
+// entire purpose is to be obeyed against this client's judgement.
+func redialWithoutAContradictedDemotion(
+	ctx context.Context,
+	network string,
+	addr string,
+	dial DialContextFunction,
+	dialErr error,
+) (net.Conn, error) {
+	if network != "tcp" && network != "udp" {
+		return nil, dialErr
+	}
+	// a literal is never narrowed, so its failure is not the narrowing's fault
+	if isIPLiteralDialAddr(addr) {
+		return nil, dialErr
+	}
+	if ControlIpFamilyPolicy() != IpFamilyAuto {
+		return nil, dialErr
+	}
+	demoted := controlFamilyDemotedFamily()
+	if demoted == 0 {
+		return nil, dialErr
+	}
+	if !controlFamilyUndemote(demoted) {
+		return nil, dialErr
+	}
+	conn, err := dial(ctx, network, addr)
+	if err != nil {
+		return nil, dialErr
+	}
+	return conn, nil
+}

--- a/control_family_dial_test.go
+++ b/control_family_dial_test.go
@@ -1,0 +1,1011 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The shape of the reported bug: the tcp connect succeeds over IPv6 (small
+// packets pass an HE tunnel), then the tls handshake times out (the large
+// ServerHello is dropped). The caller must still get a working connection.
+func TestFamilyFallbackRecoversFromAPostConnectTimeout(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	var mutex sync.Mutex
+	var dialed []string
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		mutex.Lock()
+		dialed = append(dialed, network)
+		mutex.Unlock()
+		remote := &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}
+		if network == "tcp4" {
+			remote = &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}
+		}
+		return &stubConn{remote: remote}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		if connFamily(conn) == 6 {
+			return nil, &timeoutError{}
+		}
+		return conn, nil
+	}
+
+	conn, err := dialControlTlsWithFamilyFallback(
+		context.Background(), DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := connFamily(conn); got != 4 {
+		t.Fatalf("returned an IPv%d connection, want IPv4", got)
+	}
+	mutex.Lock()
+	defer mutex.Unlock()
+	if len(dialed) != 2 || dialed[0] != "tcp" || dialed[1] != "tcp4" {
+		t.Fatalf("dialed %v, want [tcp tcp4]", dialed)
+	}
+	if controlFamilyDemotedFamily() != 6 {
+		t.Fatal("expected ipv6 to be demoted by the failure")
+	}
+}
+
+// Exactly one retry. The dial already sits inside the strategy's own dialer
+// evaluation under a 15s request budget, so a helper that retried repeatedly
+// could consume the whole budget alone and starve the other dialers.
+func TestFamilyFallbackRetriesOnlyOnce(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	var mutex sync.Mutex
+	attempts := 0
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		mutex.Lock()
+		attempts += 1
+		mutex.Unlock()
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		return nil, &timeoutError{}
+	}
+
+	_, err := dialControlTlsWithFamilyFallback(
+		context.Background(), DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if err == nil {
+		t.Fatal("expected the second failure to be returned")
+	}
+	mutex.Lock()
+	defer mutex.Unlock()
+	if attempts != 2 {
+		t.Fatalf("dialed %d times, want exactly 2", attempts)
+	}
+}
+
+// A non-timeout failure is not a path problem and must not demote or retry.
+func TestFamilyFallbackDoesNotRetryANonTimeout(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	attempts := 0
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		attempts += 1
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	certErr := errors.New("x509: certificate signed by unknown authority")
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		return nil, certErr
+	}
+
+	_, err := dialControlTlsWithFamilyFallback(
+		context.Background(), DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if !errors.Is(err, certErr) {
+		t.Fatalf("got %v, want the certificate error unwrapped", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("dialed %d times, want 1 -- a certificate failure is not a path failure", attempts)
+	}
+	if controlFamilyDemotedFamily() != 0 {
+		t.Fatal("a certificate failure must not demote a family")
+	}
+}
+
+// An explicitly family-specific dial has nowhere to fall back to.
+func TestFamilyFallbackDoesNotRetryAnExplicitFamily(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	attempts := 0
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		attempts += 1
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		return nil, &timeoutError{}
+	}
+
+	_, _ = dialControlTlsWithFamilyFallback(
+		context.Background(), DefaultConnectSettings(), "tcp6", "api.example:443", dial, handshake)
+	if attempts != 1 {
+		t.Fatalf("dialed %d times, want 1 for an explicit tcp6", attempts)
+	}
+}
+
+// The family has to be read off the connection BEFORE the handshake runs and
+// before any Close. A real tls.Conn closes the underlying connection on a
+// failed handshake -- newNormalDialTlsContext's callback does exactly that --
+// and a closed net.TCPConn is not required to keep answering RemoteAddr. Read
+// it late and `failed` is 0, so nothing is demoted and nothing is retried:
+// the fallback silently stops existing on the one path it was written for.
+//
+// forgetfulConn reproduces that: it answers RemoteAddr until it is closed and
+// nil afterwards. The brief's other tests cannot catch the ordering, because
+// stubConn's Close is a no-op that leaves RemoteAddr working forever.
+func TestFamilyFallbackReadsTheFamilyBeforeTheConnectionIsClosed(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	var mutex sync.Mutex
+	var dialed []string
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		mutex.Lock()
+		dialed = append(dialed, network)
+		mutex.Unlock()
+		if network == "tcp4" {
+			return &forgetfulConn{remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}}, nil
+		}
+		return &forgetfulConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		if connFamily(conn) == 6 {
+			// what tls.Conn.Close() does to the connection it wraps
+			conn.Close()
+			return nil, &timeoutError{}
+		}
+		return conn, nil
+	}
+
+	conn, err := dialControlTlsWithFamilyFallback(
+		context.Background(), DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := connFamily(conn); got != 4 {
+		t.Fatalf("returned an IPv%d connection, want IPv4", got)
+	}
+	mutex.Lock()
+	defer mutex.Unlock()
+	if len(dialed) != 2 || dialed[1] != "tcp4" {
+		t.Fatalf("dialed %v, want [tcp tcp4] -- the family was read too late to fall back", dialed)
+	}
+}
+
+// answers RemoteAddr until closed, then forgets, like a real net.TCPConn may.
+type forgetfulConn struct {
+	net.Conn
+	remote net.Addr
+	closed atomic.Bool
+}
+
+func (self *forgetfulConn) RemoteAddr() net.Addr {
+	if self.closed.Load() {
+		return nil
+	}
+	return self.remote
+}
+
+func (self *forgetfulConn) Close() error {
+	self.closed.Store(true)
+	return nil
+}
+
+// The platform control websocket's handshake tolerance is left alone: on its
+// budget the first handshake still gets the caller's WHOLE remaining time.
+//
+// gorilla/websocket caps the dial context at Dialer.HandshakeTimeout, 5s, and
+// 5s is below ControlFamilyFirstHandshakeTimeout + ControlFamilyRetryReserve,
+// so the bound is never applied here -- there is no room for a second attempt
+// to run in, and a bound that produced a timeout with nowhere to retry would
+// only make this path fail sooner than it does today. It loses nothing by it:
+// the demotion ledger is process-global, so the demotion the api path has the
+// budget to LEARN is already in force for this dial.
+//
+// The first handshake used to get half the caller's budget on every path.
+// Shortening the 15s tls handshake tolerance is something this product
+// deliberately does not do -- it would risk false-positive demotion for users
+// on genuinely slow links -- and halving did exactly that, implicitly and
+// hardest where the budget was smallest: 2.5s here, on the path
+// that reconnects most often, with a timeout inside it read as proof the
+// family is blackholed.
+func TestFamilyFallbackLeavesTheWebsocketBudgetUnbounded(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	// the platform control websocket's real budget, read from the settings
+	// gorilla is handed rather than restated
+	settings := DefaultConnectSettings()
+	if settings.HandshakeTimeout >=
+		settings.ControlFamilyFirstHandshakeTimeout+settings.ControlFamilyRetryReserve {
+		t.Fatalf(
+			"the websocket's %s budget now reaches the %s+%s bound threshold -- "+
+				"the first handshake on the control websocket is about to be cut short, "+
+				"which is the false positive this bound exists to avoid",
+			settings.HandshakeTimeout,
+			settings.ControlFamilyFirstHandshakeTimeout,
+			settings.ControlFamilyRetryReserve,
+		)
+	}
+	callerCtx, cancel := context.WithTimeout(context.Background(), settings.HandshakeTimeout)
+	defer cancel()
+	callerDeadline, _ := callerCtx.Deadline()
+
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		if network == "tcp4" {
+			return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}}, nil
+		}
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	var mutex sync.Mutex
+	deadlines := []time.Time{}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Error("the handshake was given a context with no deadline")
+		}
+		mutex.Lock()
+		deadlines = append(deadlines, deadline)
+		mutex.Unlock()
+		if connFamily(conn) == 6 {
+			// the handshake's OWN timeout, not the caller's: this is
+			// TlsTimeout, left at 15s
+			return nil, &timeoutError{}
+		}
+		return conn, nil
+	}
+
+	conn, err := dialControlTlsWithFamilyFallback(
+		callerCtx, settings, "tcp", "api.example:443", dial, handshake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := connFamily(conn); got != 4 {
+		t.Fatalf("returned an IPv%d connection, want IPv4", got)
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	if len(deadlines) != 2 {
+		t.Fatalf("handshaked %d times, want 2", len(deadlines))
+	}
+	if deadlines[0].Before(callerDeadline) {
+		t.Fatalf(
+			"the first handshake was cut at %s, %s short of the caller's own %s -- "+
+				"a fraction of the caller's budget is a shortened handshake tolerance, "+
+				"which this product deliberately does not do",
+			deadlines[0].Format(time.RFC3339Nano),
+			callerDeadline.Sub(deadlines[0]),
+			callerDeadline.Format(time.RFC3339Nano),
+		)
+	}
+}
+
+// The consequence, on the real websocket budget: a handshake that is merely
+// SLOW -- slower than the caller's whole 5s, so the caller's own deadline is
+// what ends it -- must not be read as a blackholed family. Under the halving
+// this demoted at 2.5s with the caller's budget still half unspent.
+func TestFamilyFallbackDoesNotDemoteASlowHandshakeOnTheWebsocketBudget(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	// above 2 * the deleted 2s minimum, so the deleted code took its dividing
+	// branch and demoted; below anything a real caller would call patient
+	callerCtx, cancel := context.WithTimeout(context.Background(), 4500*time.Millisecond)
+	defer cancel()
+
+	attempts := 0
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		attempts += 1
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	_, err := dialControlTlsWithFamilyFallback(
+		callerCtx, DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if err == nil {
+		t.Fatal("expected the timeout back")
+	}
+	if attempts != 1 {
+		t.Fatalf("dialed %d times, want 1 -- the caller's budget was gone", attempts)
+	}
+	if got := controlFamilyDemotedFamily(); got != 0 {
+		t.Fatalf("ipv%d was demoted by a handshake that only ran out of the "+
+			"caller's own time", got)
+	}
+}
+
+// The failure this helper exists to catch: a handshake that stalls until a
+// deadline of its OWN -- a blackholed path gives up only when something times
+// it out, because the kernel retransmits for minutes -- while the caller still
+// has budget. That is the case the retry can act on, and the caller must
+// receive a working connection.
+func TestFamilyFallbackRecoversFromAHandshakeThatStallsToItsOwnDeadline(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	callerCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		// a real dial on a dead context fails at once
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if network == "tcp4" {
+			return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}}, nil
+		}
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if connFamily(conn) == 6 {
+			// what newNormalDialTlsContext does: the handshake carries its own
+			// TlsTimeout inside the caller's budget. The ServerHello never
+			// arrives and the handshake ends there, with the caller's budget
+			// still alive.
+			handshakeCtx, handshakeCancel := context.WithTimeout(ctx, 200*time.Millisecond)
+			defer handshakeCancel()
+			<-handshakeCtx.Done()
+			return nil, handshakeCtx.Err()
+		}
+		return conn, nil
+	}
+
+	conn, err := dialControlTlsWithFamilyFallback(
+		callerCtx, DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if err != nil {
+		t.Fatalf("%v -- the stalled first attempt left the retry no budget", err)
+	}
+	if got := connFamily(conn); got != 4 {
+		t.Fatalf("returned an IPv%d connection, want IPv4", got)
+	}
+	if controlFamilyDemotedFamily() != 6 {
+		t.Fatal("expected ipv6 to be demoted by the stall")
+	}
+}
+
+// A request that simply runs out of budget mid-handshake proves nothing about
+// the path. Demoting there would take a user on a merely slow link off a
+// healthy family for five minutes, which is the false positive the design
+// refused to accept when it declined to shorten TlsTimeout.
+func TestFamilyFallbackDoesNotDemoteWhenTheCallersBudgetRanOut(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	// far too little left to bound a first attempt and still have a retry, so
+	// whatever the handshake reports is the caller's deadline, not the path's
+	callerCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	attempts := 0
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		attempts += 1
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	_, err := dialControlTlsWithFamilyFallback(
+		callerCtx, DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("got %v, want the caller's deadline error", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("dialed %d times, want 1 -- there was no budget to retry with", attempts)
+	}
+	if controlFamilyDemotedFamily() != 0 {
+		t.Fatal("the caller's own budget expiring must not demote a family")
+	}
+}
+
+// The route back from a demotion that took the user offline.
+//
+// The ledger is only ever written after a connect SUCCEEDED and the handshake
+// then timed out, so a demotion can be confirmed but never refuted. When the
+// family we demoted onto cannot connect at all, the dial returns at the
+// connect step and nothing is recorded -- so every control dial in the process
+// stays narrowed onto the family that just proved it does not work, for five
+// minutes and, as strikes accumulate, up to six hours.
+//
+// The dial stub resolves the network through controlDialNetwork exactly as
+// ConnectSettings.DialContext does, so the narrowing under test is the real
+// one and not a value the test handed itself.
+func TestFamilyFallbackUndoesADemotionThatCannotConnect(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+	SetControlIpFamilyPolicy(IpFamilyAuto)
+
+	if !controlFamilyDemote(6) {
+		t.Fatal("expected the demotion to take")
+	}
+	if got, _ := controlDialNetwork("tcp", "api.example:443"); got != "tcp4" {
+		t.Fatalf("precondition: controlDialNetwork = %q, want tcp4", got)
+	}
+
+	var mutex sync.Mutex
+	var dialed []string
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		resolved, err := controlDialNetwork(network, addr)
+		if err != nil {
+			return nil, err
+		}
+		mutex.Lock()
+		dialed = append(dialed, resolved)
+		mutex.Unlock()
+		if resolved == "tcp4" {
+			// the device has no ipv4 route at all
+			return nil, &net.OpError{
+				Op: "dial", Net: "tcp4", Err: errors.New("connect: network is unreachable"),
+			}
+		}
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		return conn, nil
+	}
+
+	conn, err := dialControlTlsWithFamilyFallback(
+		context.Background(), DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if err != nil {
+		t.Fatalf("%v -- the demotion steered the dial onto a family with no route "+
+			"and nothing could undo it", err)
+	}
+	if got := connFamily(conn); got != 6 {
+		t.Fatalf("returned an IPv%d connection, want IPv6", got)
+	}
+	mutex.Lock()
+	dialedCopy := append([]string{}, dialed...)
+	mutex.Unlock()
+	if len(dialedCopy) != 2 || dialedCopy[0] != "tcp4" || dialedCopy[1] != "tcp" {
+		t.Fatalf("dialed %v, want [tcp4 tcp] -- the redial must be family-agnostic "+
+			"so happy eyeballs runs again", dialedCopy)
+	}
+	if controlFamilyDemotedFamily() != 0 {
+		t.Fatal("the demotion still stands after the family it demoted onto failed to connect")
+	}
+}
+
+// A force is a developer override and is never undone by a dial failure.
+func TestFamilyFallbackDoesNotUndoAForce(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+	SetControlIpFamilyPolicy(IpFamilyForce4)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+
+	attempts := 0
+	dialErr := errors.New("connect: network is unreachable")
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		attempts += 1
+		return nil, dialErr
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		return conn, nil
+	}
+
+	_, err := dialControlTlsWithFamilyFallback(
+		context.Background(), DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+	if !errors.Is(err, dialErr) {
+		t.Fatalf("got %v, want the dial error", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("dialed %d times, want 1 -- a force must not be re-dialed around", attempts)
+	}
+	if ControlIpFamilyPolicy() != IpFamilyForce4 {
+		t.Fatal("the force was cleared by a dial failure")
+	}
+}
+
+// A second failure over the second family is not a family problem. A strike
+// that the retry could not confirm must not be left
+// standing -- it narrows every control dial in the process, including the
+// extender and h3/quic paths, on evidence the helper itself just contradicted.
+func TestFamilyFallbackRollsBackTheStrikeWhenTheRetryAlsoFails(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+
+	tests := []struct {
+		name         string
+		retryDialErr bool
+	}{
+		{"the retry cannot connect", true},
+		{"the retry connects and its handshake fails", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			controlFamilyClear()
+			defer controlFamilyClear()
+
+			dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+				if network == "tcp4" {
+					if test.retryDialErr {
+						return nil, errors.New("connect: network is unreachable")
+					}
+					return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}}, nil
+				}
+				return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+			}
+			handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+				return nil, &timeoutError{}
+			}
+
+			_, err := dialControlTlsWithFamilyFallback(
+				context.Background(), DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+			if err == nil {
+				t.Fatal("expected the original error back")
+			}
+			if got := controlFamilyDemotedFamily(); got != 0 {
+				t.Fatalf("ipv%d is still demoted after the other family failed too", got)
+			}
+			if controlFamilyStatus() != "" {
+				t.Fatalf("status %q -- a strike the retry contradicted must not survive",
+					controlFamilyStatus())
+			}
+		})
+	}
+}
+
+// The developer setting and the learned memory are independent state and never
+// mix. A timeout observed while a FORCE is in effect carries no information
+// about family choice -- there is no other family in play to compare it
+// against -- so it must not be written to the ledger.
+//
+// The real damage is deferred: a strike recorded under Force IPv4 stays armed
+// for the moment the developer sets the row back to Auto, and then steers
+// every control dial onto the family they had just forced away from.
+func TestFamilyFallbackDoesNotWriteTheLedgerUnderAForce(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+
+	for _, policy := range []IpFamilyPolicy{IpFamilyForce4, IpFamilyForce6} {
+		controlFamilyClear()
+		SetControlIpFamilyPolicy(policy)
+
+		attempts := 0
+		dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+			attempts += 1
+			return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+		}
+		handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+			return nil, &timeoutError{}
+		}
+
+		_, err := dialControlTlsWithFamilyFallback(
+			context.Background(), DefaultConnectSettings(), "tcp", "api.example:443", dial, handshake)
+		if err == nil {
+			t.Fatal("expected the timeout back")
+		}
+		if got := controlFamilyDemotedFamily(); got != 0 {
+			t.Fatalf("policy %d: ipv%d demoted while a force is in effect", policy, got)
+		}
+		if got := controlFamilyStatus(); got != "" {
+			t.Fatalf("policy %d: status %q contradicts the policy row", policy, got)
+		}
+		if attempts != 1 {
+			t.Fatalf("policy %d: dialed %d times, want 1 -- the retry would be "+
+				"rejected by the force itself", policy, attempts)
+		}
+	}
+	SetControlIpFamilyPolicy(IpFamilyAuto)
+	controlFamilyClear()
+}
+
+// deadlineConn blocks in Read until the connection is closed or a deadline in
+// the past is set, which is how crypto/tls interrupts a handshake whose context
+// expired (Conn.handshakeContext sets the underlying deadline to now). Writes
+// are accepted and dropped: the ClientHello goes out, the ServerHello never
+// comes back, which is the post-connect blackhole this feature targets.
+type deadlineConn struct {
+	remote    net.Addr
+	unblock   chan struct{}
+	closeOnce sync.Once
+}
+
+func newDeadlineConn(ip string) *deadlineConn {
+	return &deadlineConn{
+		remote:  &net.TCPAddr{IP: net.ParseIP(ip), Port: 443},
+		unblock: make(chan struct{}),
+	}
+}
+
+func (self *deadlineConn) release() {
+	self.closeOnce.Do(func() { close(self.unblock) })
+}
+
+func (self *deadlineConn) Read(b []byte) (int, error) {
+	<-self.unblock
+	return 0, os.ErrDeadlineExceeded
+}
+
+func (self *deadlineConn) Write(b []byte) (int, error) { return len(b), nil }
+func (self *deadlineConn) Close() error                { self.release(); return nil }
+func (self *deadlineConn) LocalAddr() net.Addr         { return nil }
+func (self *deadlineConn) RemoteAddr() net.Addr        { return self.remote }
+func (self *deadlineConn) SetDeadline(t time.Time) error {
+	if !t.IsZero() && !t.After(time.Now()) {
+		self.release()
+	}
+	return nil
+}
+func (self *deadlineConn) SetReadDeadline(t time.Time) error  { return self.SetDeadline(t) }
+func (self *deadlineConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// The fragment/reorder dialers go through the family fallback too.
+//
+// The helper was wired into newNormalDialTlsContext only, and that is the
+// wrong one to have alone: api posts do not race the dialers, they go through
+// HttpSerial -> serialEval, which sorts the already-succeeded dialers by
+// priority, and "fragment" is priority 0 against "normal" at 25. So the
+// fragment dialer leads every warm serial post, and shares the parallel hello
+// before that -- and it was the one dialer with no timeout classification, no
+// strike and no in-place retry.
+func TestResilientDialGoesThroughTheFamilyFallback(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	settings := DefaultConnectSettings()
+	// stands in for the handshake's own TlsTimeout expiring inside a caller
+	// budget that is still alive
+	settings.TlsTimeout = 250 * time.Millisecond
+
+	var mutex sync.Mutex
+	var dialed []string
+	var conns []*deadlineConn
+	settings.DialContextSettings = &DialContextSettings{
+		DialContext: func(ctx context.Context, network string, addr string) (net.Conn, error) {
+			mutex.Lock()
+			dialed = append(dialed, network)
+			mutex.Unlock()
+			ip := "2001:db8::1"
+			if network == "tcp4" {
+				ip = "192.0.2.1"
+			}
+			conn := newDeadlineConn(ip)
+			mutex.Lock()
+			conns = append(conns, conn)
+			mutex.Unlock()
+			return conn, nil
+		},
+	}
+
+	// the "fragment" dialer: priority 0, the first one serialEval reaches
+	dialTls := newResilientDialTlsContext(settings, true, false, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := dialTls(ctx, "tcp", "api.example:443")
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected the blackholed handshake to fail")
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	for _, c := range conns {
+		c.release()
+	}
+	if len(dialed) != 2 || dialed[0] != "tcp" || dialed[1] != "tcp4" {
+		t.Fatalf("dialed %v, want [tcp tcp4] -- the resilient dialer still "+
+			"handshakes inline with no family classification and no retry", dialed)
+	}
+}
+
+// THE POINT OF THE WHOLE FEATURE, on the budget the api path actually has.
+//
+// A handshake bounded only by TlsTimeout can never reach its own timeout: at
+// 15s it is at or above every production caller's budget, so the caller's
+// deadline always arrives first, the ctx.Err() branch declines the strike, and
+// the retry never runs. The demotion trigger was configured out of existence.
+//
+// ControlFamilyFirstHandshakeTimeout is what a stalled handshake hits instead,
+// and this pins that it leaves a retry a real amount of time to run in --
+// ControlFamilyRetryReserve at the very least -- on the api path's own
+// RequestTimeout budget, with the shipping defaults and not test-sized ones.
+func TestFamilyFallbackBoundsTheFirstHandshakeOnTheApiBudget(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	// http.Client.Timeout is RequestTimeout on every api dialer (HttpClient),
+	// and serialEval bounds the whole request by the same value
+	settings := DefaultConnectSettings()
+	callerCtx, cancel := context.WithTimeout(context.Background(), settings.RequestTimeout)
+	defer cancel()
+	callerDeadline, _ := callerCtx.Deadline()
+
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		if network == "tcp4" {
+			return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}}, nil
+		}
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	var mutex sync.Mutex
+	deadlines := []time.Time{}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Error("the handshake was given a context with no deadline")
+		}
+		mutex.Lock()
+		deadlines = append(deadlines, deadline)
+		mutex.Unlock()
+		if connFamily(conn) == 6 {
+			return nil, &timeoutError{}
+		}
+		return conn, nil
+	}
+
+	conn, err := dialControlTlsWithFamilyFallback(
+		callerCtx, settings, "tcp", "api.example:443", dial, handshake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := connFamily(conn); got != 4 {
+		t.Fatalf("returned an IPv%d connection, want IPv4", got)
+	}
+	if controlFamilyDemotedFamily() != 6 {
+		t.Fatal("expected ipv6 to be demoted -- the handshake hit a timeout of its own")
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	if len(deadlines) != 2 {
+		t.Fatalf("handshaked %d times, want 2", len(deadlines))
+	}
+	// the retry's budget: what the caller still had when the bound expired
+	left := callerDeadline.Sub(deadlines[0])
+	if left < settings.ControlFamilyRetryReserve {
+		t.Fatalf(
+			"the first handshake was given %s of the caller's %s, leaving %s for a "+
+				"retry -- want at least %s held back, or a stall simply ends at the "+
+				"caller's own deadline and nothing is learned",
+			time.Until(deadlines[0]),
+			settings.RequestTimeout,
+			left,
+			settings.ControlFamilyRetryReserve,
+		)
+	}
+	// and it is the floor that bounded it, not some fraction of the caller
+	bounded := time.Until(deadlines[0])
+	slack := 2 * time.Second
+	if bounded < settings.ControlFamilyFirstHandshakeTimeout-slack ||
+		settings.ControlFamilyFirstHandshakeTimeout+slack < bounded {
+		t.Fatalf(
+			"the first handshake got %s, want ~%s (ControlFamilyFirstHandshakeTimeout)",
+			bounded, settings.ControlFamilyFirstHandshakeTimeout)
+	}
+	// the retry gets the rest of the caller's budget, unbounded
+	if !deadlines[1].Equal(callerDeadline) {
+		t.Fatalf("the retry's deadline was %s, want the caller's own %s",
+			deadlines[1].Format(time.RFC3339Nano), callerDeadline.Format(time.RFC3339Nano))
+	}
+}
+
+// End to end, with a handshake that really stalls: it now ends at the bound
+// with the caller's budget still alive, which is the one state that records a
+// strike and runs the retry. Before the bound existed this stall ran to the
+// caller's own deadline and produced nothing -- no strike, no retry, no
+// connection.
+//
+// Test-sized durations: the shape is what is under test, and the shipping
+// values are pinned against the real budgets by the two tests either side.
+func TestFamilyFallbackDemotesAStallThatOutlastsTheBound(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	settings := DefaultConnectSettings()
+	settings.ControlFamilyFirstHandshakeTimeout = 250 * time.Millisecond
+	settings.ControlFamilyRetryReserve = 100 * time.Millisecond
+
+	// far above the bound plus the reserve, so two attempts fit
+	callerCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var mutex sync.Mutex
+	var dialed []string
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		mutex.Lock()
+		dialed = append(dialed, network)
+		mutex.Unlock()
+		if network == "tcp4" {
+			return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}}, nil
+		}
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		if connFamily(conn) == 6 {
+			// the blackhole: the ClientHello goes out and nothing comes back,
+			// so this ends only when something times it out
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return conn, nil
+	}
+
+	start := time.Now()
+	conn, err := dialControlTlsWithFamilyFallback(
+		callerCtx, settings, "tcp", "api.example:443", dial, handshake)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("%v -- the stall ran past the bound and left the retry no budget", err)
+	}
+	if got := connFamily(conn); got != 4 {
+		t.Fatalf("returned an IPv%d connection, want IPv4", got)
+	}
+	if controlFamilyDemotedFamily() != 6 {
+		t.Fatal("expected ipv6 to be demoted by the stall")
+	}
+	if 2*time.Second < elapsed {
+		t.Fatalf("took %s -- the stall ended at the caller's deadline, not at the bound",
+			elapsed)
+	}
+	mutex.Lock()
+	defer mutex.Unlock()
+	if len(dialed) != 2 || dialed[0] != "tcp" || dialed[1] != "tcp4" {
+		t.Fatalf("dialed %v, want [tcp tcp4]", dialed)
+	}
+}
+
+// The bound is a tolerance, not a target. A handshake that is slow but WORKING
+// finishes inside it and must be returned, with no strike: a demotion narrows
+// every control dial in the process for five minutes, and being on a congested
+// link is not evidence of a blackhole.
+//
+// This is the failure mode of the deleted implementation, which took a
+// FRACTION of the caller's budget instead of a floor, and so shrank the
+// tolerance exactly where the caller had least to give.
+func TestFamilyFallbackDoesNotDemoteAHandshakeThatFinishesInsideTheBound(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	settings := DefaultConnectSettings()
+	settings.ControlFamilyFirstHandshakeTimeout = 500 * time.Millisecond
+	settings.ControlFamilyRetryReserve = 100 * time.Millisecond
+
+	// 800ms is over the 600ms threshold, so the bound applies -- and under
+	// twice the bound, so HALF of it (400ms) is less than the bound. The
+	// handshake below lands between the two: inside the floor, outside the
+	// fraction the deleted implementation would have allowed.
+	callerCtx, cancel := context.WithTimeout(context.Background(), 800*time.Millisecond)
+	defer cancel()
+
+	attempts := 0
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		attempts += 1
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		// slow, and inside the bound: a congested link with a pinned P-384
+		// chain, not a path that drops large packets
+		select {
+		case <-time.After(450 * time.Millisecond):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return conn, nil
+	}
+
+	conn, err := dialControlTlsWithFamilyFallback(
+		callerCtx, settings, "tcp", "api.example:443", dial, handshake)
+	if err != nil {
+		t.Fatalf("%v -- a slow but working handshake was cut short by the bound", err)
+	}
+	if got := connFamily(conn); got != 6 {
+		t.Fatalf("returned an IPv%d connection, want the IPv6 one that worked", got)
+	}
+	if attempts != 1 {
+		t.Fatalf("dialed %d times, want 1 -- nothing failed", attempts)
+	}
+	if got := controlFamilyDemotedFamily(); got != 0 {
+		t.Fatalf("ipv%d was demoted by a handshake that succeeded", got)
+	}
+}
+
+// A caller without room for two attempts is not bounded at all. The bound
+// exists to hold budget back for a retry; where there is no retry to hold it
+// back for, taking it is pure loss -- it would end a request that was still
+// waiting, earlier than it would have ended, and learn nothing for it.
+//
+// This is what keeps the bound off the platform control websocket (5s, under
+// the 8s + 5s threshold) and off every dialer the client strategy reaches
+// after the first has already spent part of the request budget.
+func TestFamilyFallbackDoesNotBoundACallerWithNoRoomForTwoAttempts(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	settings := DefaultConnectSettings()
+	settings.ControlFamilyFirstHandshakeTimeout = 400 * time.Millisecond
+	settings.ControlFamilyRetryReserve = 200 * time.Millisecond
+
+	// below the 600ms threshold, above the bound on its own -- the shape that
+	// would be bounded if only the bound, and not the reserve, were consulted
+	callerCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	callerDeadline, _ := callerCtx.Deadline()
+
+	attempts := 0
+	var handshakeDeadline time.Time
+	dial := func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		attempts += 1
+		return &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}, nil
+	}
+	handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+		handshakeDeadline, _ = ctx.Deadline()
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	_, err := dialControlTlsWithFamilyFallback(
+		callerCtx, settings, "tcp", "api.example:443", dial, handshake)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("got %v, want the caller's own deadline error", err)
+	}
+	if !handshakeDeadline.Equal(callerDeadline) {
+		t.Fatalf(
+			"the handshake was bounded to %s, %s short of the caller's own %s -- "+
+				"there was no room for a retry, so the single attempt must get everything",
+			handshakeDeadline.Format(time.RFC3339Nano),
+			callerDeadline.Sub(handshakeDeadline),
+			callerDeadline.Format(time.RFC3339Nano),
+		)
+	}
+	if attempts != 1 {
+		t.Fatalf("dialed %d times, want 1", attempts)
+	}
+	if got := controlFamilyDemotedFamily(); got != 0 {
+		t.Fatalf("ipv%d was demoted by the caller's own budget expiring", got)
+	}
+}

--- a/control_family_test.go
+++ b/control_family_test.go
@@ -1,0 +1,794 @@
+package connect
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestControlDialNetworkForce(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  IpFamilyPolicy
+		network string
+		want    string
+		wantErr bool
+	}{
+		{"auto leaves tcp alone", IpFamilyAuto, "tcp", "tcp", false},
+		{"auto leaves udp alone", IpFamilyAuto, "udp", "udp", false},
+		{"force4 narrows tcp", IpFamilyForce4, "tcp", "tcp4", false},
+		{"force6 narrows tcp", IpFamilyForce6, "tcp", "tcp6", false},
+		{"force4 narrows udp", IpFamilyForce4, "udp", "udp4", false},
+		{"force6 narrows udp", IpFamilyForce6, "udp", "udp6", false},
+		{"force4 passes matching explicit", IpFamilyForce4, "tcp4", "tcp4", false},
+		{"force4 rejects conflicting explicit", IpFamilyForce4, "tcp6", "", true},
+		{"force6 rejects conflicting explicit", IpFamilyForce6, "udp4", "", true},
+		{"auto passes explicit through", IpFamilyAuto, "tcp6", "tcp6", false},
+		{"unknown network is untouched", IpFamilyForce4, "unix", "unix", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			SetControlIpFamilyPolicy(test.policy)
+			defer SetControlIpFamilyPolicy(IpFamilyAuto)
+			got, err := controlDialNetwork(test.network, "api.example:443")
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %s under %d", test.network, test.policy)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// A dial whose target is ALREADY AN IP LITERAL has no family choice left in
+// it, so narrowing it can never change which family is dialed -- it can only
+// turn a working dial into an instant "no suitable address found". Measured:
+// `dial tcp6 1.1.1.1:443` fails immediately.
+//
+// This is the whole fallback layer, not a corner case. The extender dialers
+// dial extenderConfig.Ip (net_extender.go) and the remote plain-DNS resolver
+// dials a configured resolver address (net_http_doh.go), both IP literals,
+// both through ConnectSettings.DialContext. A demotion learned on the api path
+// used to take every one of them down with it -- and because they fail at
+// CONNECT, none of them recorded anything that could undo the demotion.
+func TestControlDialNetworkNeverNarrowsAnIPLiteral(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+
+	tests := []struct {
+		name    string
+		policy  IpFamilyPolicy
+		demote  int
+		network string
+		addr    string
+	}{
+		{"force6 leaves an ipv4 extender literal alone", IpFamilyForce6, 0, "tcp", "192.0.2.7:443"},
+		{"force4 leaves an ipv6 extender literal alone", IpFamilyForce4, 0, "tcp", "[2001:db8::7]:443"},
+		{"a demotion of 6 leaves an ipv4 literal alone", IpFamilyAuto, 6, "tcp", "1.1.1.1:443"},
+		{"a demotion of 4 leaves an ipv6 literal alone", IpFamilyAuto, 4, "tcp", "[2606:4700:4700::1111]:53"},
+		{"a demotion leaves a bare literal alone", IpFamilyAuto, 6, "udp", "1.1.1.1"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			controlFamilyClear()
+			defer controlFamilyClear()
+			SetControlIpFamilyPolicy(test.policy)
+			defer SetControlIpFamilyPolicy(IpFamilyAuto)
+			if test.demote != 0 {
+				SetControlIpFamilyPolicy(IpFamilyAuto)
+				if !controlFamilyDemote(test.demote) {
+					t.Fatal("expected the demotion to take")
+				}
+				SetControlIpFamilyPolicy(test.policy)
+			}
+
+			got, err := controlDialNetwork(test.network, test.addr)
+			if err != nil {
+				t.Fatalf("%v -- a literal dial must never be refused", err)
+			}
+			if got != test.network {
+				t.Fatalf(
+					"got %q for %s, want %q unchanged -- narrowing a literal can only break it",
+					got, test.addr, test.network)
+			}
+		})
+	}
+}
+
+func TestSetControlIpFamilyPolicyClampsUnknown(t *testing.T) {
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+	SetControlIpFamilyPolicy(IpFamilyPolicy(99))
+	if got := ControlIpFamilyPolicy(); got != IpFamilyAuto {
+		t.Fatalf("got %d, want IpFamilyAuto", got)
+	}
+	SetControlIpFamilyPolicy(IpFamilyPolicy(-3))
+	if got := ControlIpFamilyPolicy(); got != IpFamilyAuto {
+		t.Fatalf("got %d, want IpFamilyAuto", got)
+	}
+}
+
+// Only a post-connect TIMEOUT proves a path is blackholed. Everything else is
+// a server or configuration fault, and demoting a family for one would steer
+// every user off a healthy path.
+func TestIsPathTimeoutIsNarrow(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"context deadline", context.DeadlineExceeded, true},
+		{"os deadline", os.ErrDeadlineExceeded, true},
+		{"wrapped deadline", fmt.Errorf("tls: %w", context.DeadlineExceeded), true},
+		{"net timeout", &net.OpError{Err: &timeoutError{}}, true},
+		{"certificate", &tls.CertificateVerificationError{}, false},
+		{"connection refused", &net.OpError{Err: errors.New("connection refused")}, false},
+		{"reset", errors.New("read: connection reset by peer"), false},
+		{"alpn", errors.New("tls: no application protocol"), false},
+		{"nil", nil, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isPathTimeout(test.err); got != test.want {
+				t.Fatalf("isPathTimeout(%v) = %v, want %v", test.err, got, test.want)
+			}
+		})
+	}
+}
+
+type timeoutError struct{}
+
+func (self *timeoutError) Error() string   { return "i/o timeout" }
+func (self *timeoutError) Timeout() bool   { return true }
+func (self *timeoutError) Temporary() bool { return true }
+
+// A demotion must never take the user offline. With no IPv4 on the device,
+// demoting IPv6 is refused -- and with no IPv6, demoting IPv4 is refused.
+//
+// BOTH directions, and each with a probe that answers true only for the family
+// being demoted. That is what pins `other`: with the guard's
+// `other := 4; if family == 4 { other = 6 }` mutated so `other` is always 4,
+// the demote(4) row probes 4, gets true, and the demotion is wrongly accepted.
+// A single-direction test, or a row whose probe answers true for everything,
+// cannot tell the mutant from the original.
+func TestControlFamilyDemoteRefusedWhenOtherFamilyUnusable(t *testing.T) {
+	tests := []struct {
+		name     string
+		usable   int
+		demote   int
+		wantNoop string
+	}{
+		{"no ipv4, demoting ipv6 refused", 6, 6, "tcp"},
+		{"no ipv6, demoting ipv4 refused", 4, 4, "tcp"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restore := swapControlFamilyProbe(func(family int) bool {
+				return family == test.usable
+			})
+			defer restore()
+			controlFamilyClear()
+			defer controlFamilyClear()
+
+			if controlFamilyDemote(test.demote) {
+				t.Fatalf(
+					"demoted ipv%d with no ipv%d available -- the only family "+
+						"left is the one being demoted",
+					test.demote, 10-test.demote)
+			}
+			network, err := controlDialNetwork("tcp", "api.example:443")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if network != test.wantNoop {
+				t.Fatalf("got %q, want %s -- a refused demotion must not narrow", network, test.wantNoop)
+			}
+		})
+	}
+}
+
+// The IPv6-only guard is only as good as the probe behind it, and the probe
+// had no direct test at all: all sixteen call sites inject a
+// fake, so the "IPv6-only guard" test proved the BRANCH and never the probe.
+//
+// The device this pins is the one the guard exists for: an IPv6-only handset
+// (ios has no CLAT; NAT64/DNS64 is the App Store-required configuration) with
+// this product's tunnel up. The tun carries RandomLocalIpv4's 10.a.b.h, which
+// is IsGlobalUnicast, so a probe that accepts any global-unicast address
+// answers "IPv4 is available" on a device that has no IPv4 whatsoever -- and
+// the demotion of IPv6 that follows takes the control plane offline for five
+// minutes, doubling to six hours.
+func TestProbeFamilySupportIgnoresOurOwnTunnel(t *testing.T) {
+	loopback := controlFamilyInterface{
+		name:  "lo0",
+		flags: net.FlagUp | net.FlagLoopback,
+		addrs: []net.Addr{ipNet("127.0.0.1/8"), ipNet("::1/128")},
+	}
+	// the ios/darwin shape: PacketTunnelProvider installs RandomLocalIpv4
+	utun := controlFamilyInterface{
+		name:  "utun4",
+		flags: net.FlagUp | net.FlagPointToPoint,
+		addrs: []net.Addr{ipNet("10.7.3.42/32")},
+	}
+	// the android shape, including escape mode's 192.0.2.1
+	androidTun := controlFamilyInterface{
+		name:  "tun0",
+		flags: net.FlagUp | net.FlagPointToPoint,
+		addrs: []net.Addr{ipNet("10.0.0.19/24")},
+	}
+	androidEscapeTun := controlFamilyInterface{
+		name:  "tun0",
+		flags: net.FlagUp | net.FlagPointToPoint,
+		addrs: []net.Addr{ipNet("192.0.2.1/24")},
+	}
+	cellularV6Only := controlFamilyInterface{
+		name:  "pdp_ip0",
+		flags: net.FlagUp,
+		addrs: []net.Addr{ipNet("2600:1700:1234:5678::1/64"), ipNet("fe80::1/64")},
+	}
+	// an ordinary home-lan lease. RFC1918 by range, exactly like the tun's
+	// address, and it MUST still count: rejecting private ranges outright
+	// would answer "no IPv4" for most of the userbase.
+	wifi := controlFamilyInterface{
+		name:  "en0",
+		flags: net.FlagUp,
+		addrs: []net.Addr{ipNet("192.168.1.20/24")},
+	}
+	downEthernet := controlFamilyInterface{
+		name:  "en1",
+		flags: 0,
+		addrs: []net.Addr{ipNet("192.168.5.7/24")},
+	}
+
+	tests := []struct {
+		name   string
+		ifaces []controlFamilyInterface
+		want4  bool
+		want6  bool
+	}{
+		{
+			"ipv6-only iphone with our tunnel up",
+			[]controlFamilyInterface{loopback, cellularV6Only, utun},
+			false, true,
+		},
+		{
+			"ipv6-only android with our tunnel up",
+			[]controlFamilyInterface{loopback, cellularV6Only, androidTun},
+			false, true,
+		},
+		{
+			"ipv6-only android in escape mode",
+			[]controlFamilyInterface{loopback, cellularV6Only, androidEscapeTun},
+			false, true,
+		},
+		{
+			"dual-stack wifi with our tunnel up",
+			[]controlFamilyInterface{loopback, wifi, cellularV6Only, utun},
+			true, true,
+		},
+		{
+			"ipv4-only wifi",
+			[]controlFamilyInterface{loopback, wifi},
+			true, false,
+		},
+		{
+			"loopback alone is not connectivity",
+			[]controlFamilyInterface{loopback},
+			false, false,
+		},
+		{
+			"an interface that is down carries no path",
+			[]controlFamilyInterface{loopback, downEthernet},
+			false, false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restore := swapControlFamilyInterfaces(
+				func() ([]controlFamilyInterface, error) { return test.ifaces, nil })
+			defer restore()
+
+			if got := probeFamilySupport(4); got != test.want4 {
+				t.Fatalf("probeFamilySupport(4) = %v, want %v", got, test.want4)
+			}
+			if got := probeFamilySupport(6); got != test.want6 {
+				t.Fatalf("probeFamilySupport(6) = %v, want %v", got, test.want6)
+			}
+		})
+	}
+}
+
+// An unreadable interface table is NO EVIDENCE, and the only job this probe
+// has is to refuse a dangerous demotion. Failing open answers "yes, the other
+// family works" on a device nothing is known about, which is the one answer
+// that can take the control plane down. This repo already documents that
+// mobile interface enumeration can be restricted (see LocalIpv4Networks).
+func TestProbeFamilySupportFailsClosedOnEnumerationError(t *testing.T) {
+	restore := swapControlFamilyInterfaces(
+		func() ([]controlFamilyInterface, error) {
+			return nil, errors.New("operation not permitted")
+		})
+	defer restore()
+
+	if probeFamilySupport(4) {
+		t.Fatal("probeFamilySupport(4) said yes with no readable interface table")
+	}
+	if probeFamilySupport(6) {
+		t.Fatal("probeFamilySupport(6) said yes with no readable interface table")
+	}
+
+	// and the guard it feeds must therefore refuse the demotion
+	controlFamilyClear()
+	defer controlFamilyClear()
+	if controlFamilyDemote(6) {
+		t.Fatal("demoted ipv6 on a device whose interfaces could not be read")
+	}
+}
+
+func ipNet(cidr string) *net.IPNet {
+	ip, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	network.IP = ip
+	return network
+}
+
+// The POLICY accessor must never reflect a learned demotion. A ui row that
+// read back "Force IPv4" because the heuristic fired could not be set back to
+// Auto -- it would already appear not to be Auto. The demotion is visible
+// through controlFamilyStatus instead, which is what the ui shows beside the
+// policy. This is asserted HERE rather than in the sdk because
+// controlFamilyDemote is only reachable from this package.
+func TestControlIpFamilyPolicyIgnoresDemotion(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+	SetControlIpFamilyPolicy(IpFamilyAuto)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+
+	if !controlFamilyDemote(6) {
+		t.Fatal("expected the demotion to take")
+	}
+	if got := ControlIpFamilyPolicy(); got != IpFamilyAuto {
+		t.Fatalf("policy reads %d after a demotion, want IpFamilyAuto -- "+
+			"a demotion must never be reported as a policy the user set", got)
+	}
+	if controlFamilyStatus() == "" {
+		t.Fatal("expected a non-empty status while a demotion is live -- " +
+			"the ui has no other way to tell auto-with-a-demotion from plain auto")
+	}
+}
+
+func TestControlFamilyDemoteNarrowsToTheOtherFamily(t *testing.T) {
+	tests := []struct {
+		name   string
+		demote int
+		want   string
+	}{
+		{"demote 6 narrows to tcp4", 6, "tcp4"},
+		{"demote 4 narrows to tcp6", 4, "tcp6"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restore := swapControlFamilyProbe(func(int) bool { return true })
+			defer restore()
+			controlFamilyClear()
+			defer controlFamilyClear()
+
+			if !controlFamilyDemote(test.demote) {
+				t.Fatal("expected the demotion to take")
+			}
+			network, err := controlDialNetwork("tcp", "api.example:443")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if network != test.want {
+				t.Fatalf("got %q, want %s", network, test.want)
+			}
+			if controlFamilyStatus() == "" {
+				t.Fatal("expected a non-empty status while a demotion is live")
+			}
+		})
+	}
+}
+
+// A force beats the ledger in both directions -- it is an explicit override,
+// which is the whole point of the setting.
+func TestForceBeatsDemotion(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+	controlFamilyDemote(6)
+
+	SetControlIpFamilyPolicy(IpFamilyForce6)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+	network, err := controlDialNetwork("tcp", "api.example:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if network != "tcp6" {
+		t.Fatalf("got %q, want tcp6 -- an explicit force outranks a demotion", network)
+	}
+}
+
+func TestControlFamilyBackoffDoublesAndCaps(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	base := time.Unix(1750000000, 0)
+	now := base
+	restoreClock := swapControlFamilyClock(func() time.Time { return now })
+	defer restoreClock()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	controlFamilyDemote(6)
+	if got := controlFamilyDemotedUntil(6).Sub(base); got != controlFamilyDemotionBase {
+		t.Fatalf("first demotion lasts %s, want %s", got, controlFamilyDemotionBase)
+	}
+	controlFamilyDemote(6)
+	if got := controlFamilyDemotedUntil(6).Sub(base); got != 2*controlFamilyDemotionBase {
+		t.Fatalf("second demotion lasts %s, want %s", got, 2*controlFamilyDemotionBase)
+	}
+	for i := 0; i < 20; i += 1 {
+		controlFamilyDemote(6)
+	}
+	if got := controlFamilyDemotedUntil(6).Sub(base); got != controlFamilyDemotionMax {
+		t.Fatalf("demotion lasts %s, want the %s cap", got, controlFamilyDemotionMax)
+	}
+}
+
+func TestControlFamilyDemotionExpires(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	now := time.Unix(1750000000, 0)
+	restoreClock := swapControlFamilyClock(func() time.Time { return now })
+	defer restoreClock()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	controlFamilyDemote(6)
+	now = now.Add(controlFamilyDemotionBase + time.Second)
+	network, err := controlDialNetwork("tcp", "api.example:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if network != "tcp" {
+		t.Fatalf("got %q, want tcp once the demotion expired", network)
+	}
+	if controlFamilyStatus() != "" {
+		t.Fatal("expected an empty status once the demotion expired")
+	}
+}
+
+// A network change invalidates everything learned about the old path.
+func TestNetworkChangedClearsTheLedger(t *testing.T) {
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	controlFamilyDemote(6)
+	NetworkChanged()
+	network, err := controlDialNetwork("tcp", "api.example:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if network != "tcp" {
+		t.Fatalf("got %q, want tcp after a network change", network)
+	}
+}
+
+func TestConnFamily(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.Addr
+		want int
+	}{
+		{"ipv4", &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}, 4},
+		{"ipv4 in ipv6 form", &net.TCPAddr{IP: net.ParseIP("::ffff:192.0.2.1"), Port: 443}, 4},
+		{"ipv6", &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}, 6},
+		{"nil", nil, 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := connFamily(&stubConn{remote: test.addr}); got != test.want {
+				t.Fatalf("got %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+type stubConn struct {
+	net.Conn
+	remote net.Addr
+}
+
+func (self *stubConn) RemoteAddr() net.Addr { return self.remote }
+
+func (self *stubConn) Close() error { return nil }
+
+// The family must be a LITERAL token, never derived from the address. The sdk
+// log redactor rewrites both IPv4 and IPv6 literals to the same opaque token
+// shape, so a redacted bundle -- the mode users are asked to send -- cannot
+// tell a v4 dial from a v6 dial by its address.
+func TestControlDialFamilyLineCarriesALiteralFamilyToken(t *testing.T) {
+	conn := &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 443}}
+	line := controlDialFamilyLine("api", "tcp", "api.example:443", conn, nil)
+	if !strings.Contains(line, "family=6") {
+		t.Fatalf("line %q does not carry a literal family token", line)
+	}
+	if !strings.Contains(line, "tag=api") {
+		t.Fatalf("line %q does not name the dial tag", line)
+	}
+
+	conn4 := &stubConn{remote: &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 443}}
+	line4 := controlDialFamilyLine("platform", "tcp", "connect.example:443", conn4, nil)
+	if !strings.Contains(line4, "family=4") {
+		t.Fatalf("line %q does not carry a literal family token", line4)
+	}
+}
+
+// A failed dial has no connection to read a family from, and must say so
+// rather than claim one.
+func TestControlDialFamilyLineOnFailure(t *testing.T) {
+	line := controlDialFamilyLine("api", "tcp4", "api.example:443", nil, errors.New("i/o timeout"))
+	if !strings.Contains(line, "family=?") {
+		t.Fatalf("line %q should report an unknown family on failure", line)
+	}
+	if !strings.Contains(line, "err=") {
+		t.Fatalf("line %q should carry the error", line)
+	}
+}
+
+// The h3/quic transport resolves a name to exactly ONE udp address and dials
+// it, with no family race of any kind. It is the fallback carrier that is
+// supposed to rescue a stalled h1, so if it picks the same broken family the
+// fallback is lost too.
+func TestPickControlUDPAddrHonorsPolicyAndDemotion(t *testing.T) {
+	v6 := net.IPAddr{IP: net.ParseIP("2001:db8::1")}
+	v4 := net.IPAddr{IP: net.ParseIP("192.0.2.1")}
+	addrs := []net.IPAddr{v6, v4}
+
+	restore := swapControlFamilyProbe(func(int) bool { return true })
+	defer restore()
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	// auto with nothing learned ties toward IPv4, matching
+	// net.ResolveUDPAddr's own tie-break -- NOT the resolver's list order
+	// (addrs[0] here is v6), so a dual-stack, v6-first RFC 6724 ordering does
+	// not silently become the new default family.
+	if got := pickControlIPAddr(addrs); !got.IP.Equal(v4.IP) {
+		t.Fatalf("got %v, want the IPv4 tie-break address", got.IP)
+	}
+
+	// a demotion moves the pick off the demoted family
+	controlFamilyDemote(6)
+	if got := pickControlIPAddr(addrs); !got.IP.Equal(v4.IP) {
+		t.Fatalf("got %v, want the IPv4 address once IPv6 is demoted", got.IP)
+	}
+	controlFamilyClear()
+
+	// demoting the OTHER family is the assertion that actually distinguishes
+	// the demotion branch from the IPv4-first Auto default above: Auto alone
+	// already answers v4, so demote(6)+want=v4 above cannot fail if the
+	// demotion branch is deleted. demote(4) must move the pick to v6.
+	controlFamilyDemote(4)
+	if got := pickControlIPAddr(addrs); !got.IP.Equal(v6.IP) {
+		t.Fatalf("got %v, want the IPv6 address once IPv4 is demoted", got.IP)
+	}
+	controlFamilyClear()
+
+	// a force wins outright
+	SetControlIpFamilyPolicy(IpFamilyForce4)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+	if got := pickControlIPAddr(addrs); !got.IP.Equal(v4.IP) {
+		t.Fatalf("got %v, want the IPv4 address under force4", got.IP)
+	}
+
+	// force6 is the assertion that distinguishes the force switch from the
+	// IPv4-first Auto default, pinned here at the unit level and not only
+	// through the /etc/hosts-dependent resolveEgressUDPAddr test.
+	SetControlIpFamilyPolicy(IpFamilyForce6)
+	if got := pickControlIPAddr(addrs); !got.IP.Equal(v6.IP) {
+		t.Fatalf("got %v, want the IPv6 address under force6", got.IP)
+	}
+}
+
+// With no address of the preferred family, the pick falls back rather than
+// failing: a forced family that the name does not publish must not make the
+// transport unusable.
+func TestPickControlUDPAddrFallsBackWhenNoAddressMatches(t *testing.T) {
+	v6 := net.IPAddr{IP: net.ParseIP("2001:db8::1")}
+	SetControlIpFamilyPolicy(IpFamilyForce4)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+	if got := pickControlIPAddr([]net.IPAddr{v6}); !got.IP.Equal(v6.IP) {
+		t.Fatalf("got %v, want the only available address", got.IP)
+	}
+}
+
+// EgressInterfaceIndex is a (index4, index6) pair, and both being set at once
+// is the NORMAL bound configuration -- the Windows service updates both on
+// every network change (see EgressInterfaceIndex's doc comment) -- not an
+// edge case. With both set the bind constrains nothing about family, so an
+// explicit Force4/Force6 must still win; only a bind that names exactly one
+// family may override the pick.
+func TestEgressBoundIPAddrIgnoresNonConstrainingBind(t *testing.T) {
+	v6 := net.IPAddr{IP: net.ParseIP("2001:db8::1")}
+	v4 := net.IPAddr{IP: net.ParseIP("192.0.2.1")}
+	addrs := []net.IPAddr{v6, v4} // v6 first, so a buggy "take addrs[0]" loop is caught
+
+	SetControlIpFamilyPolicy(IpFamilyForce4)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+	pick := pickControlIPAddr(addrs)
+	if !pick.IP.Equal(v4.IP) {
+		t.Fatalf("precondition: pickControlIPAddr under force4 = %v, want v4", pick.IP)
+	}
+
+	// both indexes set: not a family constraint. The forced pick must survive
+	// untouched, even though addrs[0] (v6) has a nonzero index too.
+	if got := egressBoundIPAddr(addrs, 16, 23, pick); !got.IP.Equal(v4.IP) {
+		t.Fatalf("got %v, want the forced address unchanged by a both-set bind", got.IP)
+	}
+
+	// neither index set: also not a constraint, pick stands.
+	if got := egressBoundIPAddr(addrs, 0, 0, pick); !got.IP.Equal(v4.IP) {
+		t.Fatalf("got %v, want the forced address unchanged by an unset bind", got.IP)
+	}
+}
+
+// Exactly one index set IS a hard family constraint and must override even an
+// opposite Force, because the socket literally cannot carry the other family.
+func TestEgressBoundIPAddrOverridesForceWhenSingleFamilyBound(t *testing.T) {
+	v6 := net.IPAddr{IP: net.ParseIP("2001:db8::1")}
+	v4 := net.IPAddr{IP: net.ParseIP("192.0.2.1")}
+	addrs := []net.IPAddr{v6, v4}
+
+	SetControlIpFamilyPolicy(IpFamilyForce4)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+	pick := pickControlIPAddr(addrs)
+
+	if got := egressBoundIPAddr(addrs, 0, 23, pick); !got.IP.Equal(v6.IP) {
+		t.Fatalf("got %v, want the v6-bound address to override force4", got.IP)
+	}
+}
+
+// A demotion learned on one path must not be applied unchecked on the next.
+//
+// The ledger's only invalidation is AddNetworkChangeListener(controlFamilyClear),
+// and connect.NetworkChanged() has exactly one caller in the whole tree --
+// DeviceLocal. On ios that means the listener fires in the network extension
+// and NEVER in the app process, which is the process that dials pre-login and
+// whenever the tunnel is down: regimes 1 and 3 of the design's own table, and
+// the state a user is in when they open the Developer menu to fix this. Android
+// registers its callbacks from initDevice, so it is exposed the same way while
+// signed out. So an app-process demotion could stand for up to six hours with
+// no path change ever clearing it.
+//
+// The self-inflicted-outage guard is therefore evaluated on USE as well as on
+// record: a demotion can never be applied on a path where recording it would
+// have been refused.
+func TestADemotionIsRevalidatedOnUseNotOnlyWhenRecorded(t *testing.T) {
+	controlFamilyClear()
+	defer controlFamilyClear()
+
+	// learned on a dual-stack wifi with a broken HE ipv6 path
+	restoreDualStack := swapControlFamilyProbe(func(int) bool { return true })
+	if !controlFamilyDemote(6) {
+		t.Fatal("expected the demotion to take on a dual-stack path")
+	}
+	if got, _ := controlDialNetwork("tcp", "api.example:443"); got != "tcp4" {
+		t.Fatalf("precondition: controlDialNetwork = %q, want tcp4", got)
+	}
+	restoreDualStack()
+
+	// the user joins an ipv6-only cellular / NAT64 network. No NetworkChanged()
+	// arrives, because in this process nothing can call it.
+	restore := swapControlFamilyProbe(func(family int) bool { return family == 6 })
+	defer restore()
+
+	if got := controlFamilyDemotedFamily(); got != 0 {
+		t.Fatalf("ipv%d is still demoted on a path with no ipv4 at all", got)
+	}
+	network, err := controlDialNetwork("tcp", "api.example:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if network != "tcp" {
+		t.Fatalf("narrowed to %q on a path with no ipv4 -- every control dial "+
+			"would fail with no route until the backoff expired", network)
+	}
+	if got := controlFamilyStatus(); got != "" {
+		t.Fatalf("status %q describes a demotion the dialer is no longer acting on", got)
+	}
+	if got := pickControlIPAddr([]net.IPAddr{
+		{IP: net.ParseIP("2001:db8::1")},
+		{IP: net.ParseIP("192.0.2.1")},
+	}); !got.IP.Equal(net.ParseIP("192.0.2.1")) {
+		// auto with nothing live ties toward ipv4; the assertion that matters
+		// is that the stale demotion of 6 is not steering this pick
+		t.Fatalf("h3/quic pick %v is still steered by the stale demotion", got.IP)
+	}
+}
+
+// The use-time guard has its own copy of "which family is the OTHER one", and
+// that copy needs the same discriminating table that pinned the copy in
+// controlFamilyDemote (TestControlFamilyDemoteRefusedWhenOtherFamilyUnusable
+// above). Same defect class, reintroduced in new code.
+//
+// With controlFamilyLiveDemotion's `other := 4; if live == 4 { other = 6 }`
+// mutated so `other` is always 4, the ipv6 row cannot tell the difference --
+// it probes 4 either way. Only the ipv4 row can: the mutant re-validates a
+// demotion of IPv4 against probe(4), which is the family it just demoted, gets
+// true, and keeps steering every control dial in the process onto IPv6 on a
+// device that has no IPv6 at all. That is the self-inflicted outage the guard
+// exists to prevent, arrived at through the guard itself.
+//
+// Both rows demote on a dual-stack path first, because recording a demotion is
+// itself guarded: the ledger cannot be seeded into the state under test any
+// other way.
+func TestALiveDemotionIsRevalidatedAgainstTheOtherFamily(t *testing.T) {
+	tests := []struct {
+		name   string
+		demote int
+		// the only family with a path once the device has moved
+		usable int
+	}{
+		{"ipv6 demoted, then the path loses ipv4", 6, 6},
+		{"ipv4 demoted, then the path loses ipv6", 4, 4},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			controlFamilyClear()
+			defer controlFamilyClear()
+
+			// learned where the guard permits it: both families present
+			restoreDualStack := swapControlFamilyProbe(func(int) bool { return true })
+			if !controlFamilyDemote(test.demote) {
+				t.Fatalf("precondition: demoting ipv%d on a dual-stack path was refused", test.demote)
+			}
+			restoreDualStack()
+
+			// the device moves to a path carrying ONLY the demoted family
+			restore := swapControlFamilyProbe(func(family int) bool {
+				return family == test.usable
+			})
+			defer restore()
+
+			if got := controlFamilyDemotedFamily(); got != 0 {
+				t.Fatalf(
+					"ipv%d is still demoted on a path with no ipv%d -- the guard "+
+						"was re-checked against the demoted family instead of the other one",
+					got, 10-test.usable)
+			}
+			network, err := controlDialNetwork("tcp", "api.example:443")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if network != "tcp" {
+				t.Fatalf(
+					"narrowed to %q on a path that has no such family -- every "+
+						"control dial would fail with no route until the backoff expired",
+					network)
+			}
+			if got := controlFamilyStatus(); got != "" {
+				t.Fatalf("status %q describes a demotion the dialer is no longer acting on", got)
+			}
+		})
+	}
+}

--- a/egress_dial.go
+++ b/egress_dial.go
@@ -69,23 +69,34 @@ func egressAwareResolver(custom *net.Resolver) *net.Resolver {
 	return egressResolver()
 }
 
-// resolveEgressUDPAddr is net.ResolveUDPAddr for control dials: while this
-// process's own sockets are steered around the tunnel it provides, it resolves
-// through the egress-bound resolver instead of the OS resolver, preferring an
-// address family the bind can actually carry. On a platform with no egress
-// escape, or with none in force, it is exactly net.ResolveUDPAddr.
+// resolveEgressUDPAddr is net.ResolveUDPAddr for control dials, made
+// family-aware: while this process's own sockets are steered around the
+// tunnel it provides, it resolves through the egress-bound resolver instead
+// of the OS resolver. On a platform with no egress escape, or with none in
+// force -- which is every mobile build, since egressBound() is never true
+// there -- it resolves through the OS resolver instead. Either way, the
+// address returned is chosen by pickControlIPAddr rather than taken as the
+// resolver's first result, so a forced family or a live demotion applies on
+// both paths.
+//
+// While bound, an interface index that is set for exactly one family (the
+// normal single-homed shape) is a hard constraint and overrides the pick;
+// when both are set (or neither), the bind constrains nothing about family
+// and the preference from pickControlIPAddr stands.
 //
 // This is the H3/QUIC platform transport's name path (transport.go), and it is
 // the second half of the Linux fix: pinning the resolver into NetDialer alone
 // would leave these three call sites resolving through the captured stub.
 func resolveEgressUDPAddr(ctx context.Context, addr string) (*net.UDPAddr, error) {
 	resolver := egressResolver()
-	if resolver == nil || !egressBound() {
+	bound := resolver != nil && egressBound()
+	if !bound {
 		// Keep the platform resolver but not net.ResolveUDPAddr: the caller
 		// supplied a lifecycle context specifically so a transport shutdown can
 		// interrupt a name lookup.
 		resolver = net.DefaultResolver
 	}
+
 	host, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
@@ -94,7 +105,7 @@ func resolveEgressUDPAddr(ctx context.Context, addr string) (*net.UDPAddr, error
 	if err != nil {
 		return nil, fmt.Errorf("resolve %s: non-numeric port: %w", addr, err)
 	}
-	// an ip literal needs no resolution
+	// an ip literal needs no resolution and has no family choice to make
 	if ip, ipErr := netip.ParseAddr(host); ipErr == nil {
 		return &net.UDPAddr{IP: net.IP(ip.AsSlice()), Port: port, Zone: ip.Zone()}, nil
 	}
@@ -105,16 +116,36 @@ func resolveEgressUDPAddr(ctx context.Context, addr string) (*net.UDPAddr, error
 	if len(addrs) == 0 {
 		return nil, fmt.Errorf("resolve %s: no addresses", host)
 	}
-	index4, index6 := EgressInterfaceIndex()
-	pick := addrs[0]
+	pick := pickControlIPAddr(addrs)
+	if bound {
+		index4, index6 := EgressInterfaceIndex()
+		pick = egressBoundIPAddr(addrs, index4, index6, pick)
+	}
+	return &net.UDPAddr{IP: pick.IP, Port: port, Zone: pick.Zone}, nil
+}
+
+// egressBoundIPAddr applies an interface-index bind's family constraint on
+// top of pickControlIPAddr's preference, when the bind actually expresses
+// one. Only a SINGLE family's index being set is a family constraint. With
+// both indexes set -- the normal shape while the Windows service holds the
+// tunnel up, per EgressInterfaceIndex's doc comment -- the bind constrains
+// nothing about family: a naive "first address whose family has a nonzero
+// index" loop would match addrs[0] on its very first iteration regardless of
+// family, silently discarding pick (and with it any Force4/Force6 or
+// demotion). With neither index set there is no bind at all. So the override
+// only runs when exactly one of index4/index6 is nonzero; otherwise pick
+// stands unchanged.
+func egressBoundIPAddr(addrs []net.IPAddr, index4 uint32, index6 uint32, pick net.IPAddr) net.IPAddr {
+	if (index4 == 0) == (index6 == 0) {
+		return pick
+	}
 	for _, a := range addrs {
 		is4 := a.IP.To4() != nil
 		if (is4 && index4 != 0) || (!is4 && index6 != 0) {
-			pick = a
-			break
+			return a
 		}
 	}
-	return &net.UDPAddr{IP: pick.IP, Port: port, Zone: pick.Zone}, nil
+	return pick
 }
 
 // usableEgressDnsServer reports whether an adapter-configured resolver can be
@@ -194,6 +225,18 @@ func controlDialThrottle(key string) *logThrottle {
 // `bound` is whether this dial path rides the egress-bound dialer — false
 // names a path that is in-tunnel by design (e.g. the mux's tunnel DoH).
 func logControlDialResult(log Logger, tag string, bound bool, network string, addr string, conn net.Conn, err error) {
+	l := loggerOrDefault(log)
+
+	// The family line is NOT gated on egressBound(). The [egress]dial line
+	// below is desktop-only by design -- it reports an interface binding that
+	// only Windows and macOS ever force -- but Android and iOS are the two
+	// platforms where a broken address family is actually reported, and until
+	// this line existed no mobile bundle at any verbosity could say which
+	// family a control dial used.
+	if ok, _ := controlDialThrottle("family|" + tag + "|" + addr).Allow(time.Now()); ok {
+		l.Infof("%s\n", controlDialFamilyLine(tag, network, addr, conn, err))
+	}
+
 	if !egressBound() {
 		return
 	}
@@ -210,7 +253,6 @@ func logControlDialResult(log Logger, tag string, bound bool, network string, ad
 	if 0 < suppressed {
 		suffix = fmt.Sprintf(" (%d suppressed)", suppressed)
 	}
-	l := loggerOrDefault(log)
 	if err != nil {
 		l.Infof("[egress]dial tag=%s %s %s if=4:%d/6:%d bound=%s err=%s%s\n", tag, network, addr, index4, index6, boundStr, err, suffix)
 	} else {

--- a/egress_dial_sites_test.go
+++ b/egress_dial_sites_test.go
@@ -28,7 +28,8 @@ var allowedRawDialSites = map[string]map[string]string{
 		"net.Dial": "connect()-only UDP local-address probe; no packet is sent",
 	},
 	"egress_dial.go": {
-		"net.DefaultResolver": "the context-aware no-egress path inside resolveEgressUDPAddr itself",
+		"net.DefaultResolver": "the context-aware no-egress path inside resolveEgressUDPAddr itself, " +
+			"resolving to a list so pickControlIPAddr can honor the family policy",
 	},
 	"ice_resolve_net.go": {
 		"net.DefaultResolver": "the lifecycle-aware fallback inside the per-peer egress resolver",

--- a/egress_resolver_test.go
+++ b/egress_resolver_test.go
@@ -149,4 +149,40 @@ func TestResolveEgressUDPAddrUnboundMatchesNet(t *testing.T) {
 	if udpAddr.Port != want.Port {
 		t.Fatalf("got %s want %s", udpAddr, want)
 	}
+	// net.ResolveUDPAddr's own tie-break is IPv4-first (addrs.first(isIPv4),
+	// GOROOT/src/net/ipsock.go); pickControlIPAddr must reproduce it exactly
+	// so dropping the direct net.ResolveUDPAddr call did not quietly change
+	// the default family this path dials.
+	if !udpAddr.IP.Equal(want.IP) {
+		t.Fatalf("got %s want %s (family tie-break must match net.ResolveUDPAddr)", udpAddr, want)
+	}
+}
+
+// resolveEgressUDPAddr is the actual call site the H3/QUIC transport uses;
+// pinning pickControlIPAddr alone does not prove it is wired in here. Both
+// force4 and force6 pick a real address because /etc/hosts publishes both
+// 127.0.0.1 and ::1 for "localhost", and with SetEgressInterfaceIndex(0, 0)
+// this exercises the unbound branch -- the only branch ever taken on mobile,
+// where this fix matters.
+func TestResolveEgressUDPAddrHonorsForcedFamily(t *testing.T) {
+	SetEgressInterfaceIndex(0, 0)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+
+	SetControlIpFamilyPolicy(IpFamilyForce4)
+	got4, err := resolveEgressUDPAddr(context.Background(), "localhost:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got4.IP.To4() == nil {
+		t.Fatalf("force4: got %s, want an IPv4 address", got4)
+	}
+
+	SetControlIpFamilyPolicy(IpFamilyForce6)
+	got6, err := resolveEgressUDPAddr(context.Background(), "localhost:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got6.IP.To4() != nil || got6.IP.To16() == nil {
+		t.Fatalf("force6: got %s, want an IPv6 address", got6)
+	}
 }

--- a/net.go
+++ b/net.go
@@ -3,7 +3,6 @@ package connect
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 	"time"
 
@@ -31,6 +30,10 @@ func DefaultConnectSettings() *ConnectSettings {
 			Interval: 5 * time.Second,
 			Count:    1,
 		},
+
+		ControlFamilyFirstHandshakeTimeout: 8 * time.Second,
+		ControlFamilyRetryReserve:          5 * time.Second,
+
 		TlsConfig: tlsConfig,
 	}
 }
@@ -49,6 +52,52 @@ type ConnectSettings struct {
 	KeepAliveTimeout time.Duration
 	KeepAliveConfig  net.KeepAliveConfig
 
+	// ControlFamilyFirstHandshakeTimeout bounds the FIRST tls handshake of a
+	// control dial (dialControlTlsWithFamilyFallback) so that the retry over
+	// the other address family has somewhere to run inside the caller's own
+	// budget. It is what a stalled handshake hits instead of the caller's
+	// deadline, and hitting it is what records a demotion.
+	//
+	// A FLOOR, not a fraction of the caller's budget. A fraction scales down
+	// with the caller and turns a merely slow handshake into "this family is
+	// blackholed" -- halving the platform control websocket's 5s gave the
+	// first handshake 2.5s, which a congested mobile link reaches with a
+	// pinned P-384 chain and nothing wrong. A fixed floor cannot do that: 8s
+	// is more than the whole of `HandshakeTimeout`, and `HandshakeTimeout` is
+	// the budget in which every shipping platform websocket dial already
+	// completes a tcp connect, this same tls handshake AND an http upgrade.
+	// A handshake past 8s is one this product already treats as failed
+	// everywhere else.
+	//
+	// It is deliberately NOT `TlsTimeout`: at 15s it is at or above every
+	// production caller's own budget, so nothing ever reaches it and the
+	// retry never runs (see dialControlTlsWithFamilyFallback).
+	//
+	// <= 0 disables the bound; the first handshake then gets the caller's
+	// whole remaining budget.
+	ControlFamilyFirstHandshakeTimeout time.Duration
+
+	// ControlFamilyRetryReserve is how much of the caller's budget must
+	// remain AFTER a bounded first handshake before the bound is applied at
+	// all. Below `ControlFamilyFirstHandshakeTimeout + ControlFamilyRetryReserve`
+	// the first handshake is left unbounded, because a bound that produces a
+	// timeout with no room to retry is strictly worse than no bound: it turns
+	// a request that would have kept waiting into one that fails early.
+	//
+	// `HandshakeTimeout`'s 5s again, for the same reason: it is this
+	// codebase's own statement of what a COMPLETE control dial needs, so a
+	// retry given that much is given as much as a whole production websocket
+	// dial gets.
+	//
+	// This is also what keeps the bound off the platform control websocket.
+	// gorilla caps that dial context at `HandshakeTimeout`, and 5s is less
+	// than 8s + 5s, so it is never bounded and its handshake tolerance is
+	// untouched. It does not need its own retry: the demotion ledger is
+	// process-global, so what the api path learns is already in force here.
+	//
+	// <= 0 disables the bound.
+	ControlFamilyRetryReserve time.Duration
+
 	TlsConfig *tls.Config
 
 	ProxySettings *ProxySettings
@@ -56,8 +105,16 @@ type ConnectSettings struct {
 
 	DialContextSettings *DialContextSettings
 
-	DisableIpv4 bool
-	DisableIpv6 bool
+	// DialNetworkHook, when set, is called at the top of DialContext with the
+	// network string this dial will actually use -- AFTER controlDialNetwork
+	// has resolved it -- and the address.
+	//
+	// Test seam only, and deliberately here rather than on the net.Dialer's
+	// Control callback: Control only ever sees an already-family-specific
+	// network string, so a hook there cannot distinguish a "tcp4" this seam
+	// resolved from a "tcp4" the caller asked for, and cannot observe that
+	// this seam was skipped entirely.
+	DialNetworkHook func(network string, addr string)
 }
 
 // DialContextSettings carries the paired stream and packet egress seams used
@@ -73,38 +130,12 @@ type DialContextSettings struct {
 }
 
 func (self *ConnectSettings) DialContext(ctx context.Context, network string, addr string) (net.Conn, error) {
-	if self.DisableIpv4 && self.DisableIpv6 {
-		return nil, fmt.Errorf("ipv4 and ipv6 are both disabled")
+	network, networkErr := controlDialNetwork(network, addr)
+	if networkErr != nil {
+		return nil, networkErr
 	}
-	switch network {
-	case "tcp":
-		if self.DisableIpv4 {
-			network = "tcp6"
-		} else if self.DisableIpv6 {
-			network = "tcp4"
-		}
-	case "tcp4":
-		if self.DisableIpv4 {
-			return nil, fmt.Errorf("ipv4 is disabled")
-		}
-	case "tcp6":
-		if self.DisableIpv6 {
-			return nil, fmt.Errorf("ipv6 is disabled")
-		}
-	case "udp":
-		if self.DisableIpv4 {
-			network = "udp6"
-		} else if self.DisableIpv6 {
-			network = "udp4"
-		}
-	case "udp4":
-		if self.DisableIpv4 {
-			return nil, fmt.Errorf("ipv4 is disabled")
-		}
-	case "udp6":
-		if self.DisableIpv6 {
-			return nil, fmt.Errorf("ipv6 is disabled")
-		}
+	if hook := self.DialNetworkHook; hook != nil {
+		hook(network, addr)
 	}
 
 	var dialContext DialContextFunction

--- a/net_extender.go
+++ b/net_extender.go
@@ -157,6 +157,15 @@ func newExtenderDialTlsContext(
 
 		switch extenderConfig.Profile.ConnectMode {
 		case ExtenderConnectModeTcpTls:
+			// Deliberately NOT routed through dialControlTlsWithFamilyFallback,
+			// unlike the normal and resilient dialers. `authority` is built
+			// from extenderConfig.Ip, a netip.Addr, so it is always an IP
+			// LITERAL: the family is fixed by the address, there is no other
+			// family to retry onto -- `dial tcp6 1.1.1.1:443` is "no suitable
+			// address found" -- and there is no name resolution whose family
+			// choice a strike could inform. controlDialNetwork leaves literal
+			// dials unnarrowed for the same reason, which is what keeps this
+			// whole fallback layer alive under a demotion.
 			conn, err := connectSettings.DialContext(ctx, "tcp", authority)
 			if err != nil {
 				return nil, err

--- a/net_http.go
+++ b/net_http.go
@@ -74,6 +74,9 @@ func DefaultClientStrategySettings() *ClientStrategySettings {
 		MinNextConnectDelay: 100 * time.Millisecond,
 		MaxNextConnectDelay: 1000 * time.Millisecond,
 
+		Http2SendPingTimeout: 10 * time.Second,
+		Http2PingTimeout:     5 * time.Second,
+
 		ConnectSettings: *DefaultConnectSettings(),
 	}
 	// A configured process budget identifies an embedded/mobile client. Bound
@@ -156,6 +159,18 @@ type ClientStrategySettings struct {
 	Http2MaxReceiveBufferPerConnection int
 	Http2MaxReceiveBufferPerStream     int
 
+	// HTTP/2 health check for POOLED control-plane connections. Go performs no
+	// health check at all when SendPingTimeout is zero (net/http.HTTP2Config:
+	// "If zero, no health check is performed"), so a connection that connected
+	// cleanly and later went dark stays in the idle pool and every later
+	// request multiplexed onto it hangs to the request timeout.
+	//
+	// Settings fields rather than package constants, per CONSTANTAUDIT.md:
+	// they are per-connection tunables and the settings struct that owns the
+	// transport reaches the use site directly.
+	Http2SendPingTimeout time.Duration
+	Http2PingTimeout     time.Duration
+
 	// retry a GET whose RESPONSE status is in `GetRetryStatusCodes` —
 	// transient gateway statuses meaning the lb momentarily had no healthy
 	// upstream (the edge of a deploy). The strategy already retries
@@ -218,53 +233,59 @@ func newNormalDialTlsContext(
 	nextProtos []string,
 ) DialTlsContextFunction {
 	tlsConfig := newClientTlsConfig(settings.TlsConfig, nextProtos)
-	if settings.ProxySettings == nil && settings.DialContextSettings == nil {
-		netDialer := settings.NetDialer()
-		tlsDialer := &tls.Dialer{
-			NetDialer: netDialer,
-			Config:    tlsConfig,
-		}
-		return tlsDialer.DialContext
-	}
+	// Every dial takes the explicit path below, including the mobile shape
+	// (no proxy, no injected dial context) that used to shortcut to a raw
+	// tls.Dialer here. That shortcut bypassed ConnectSettings.DialContext, so
+	// the address-family policy expressed there was honored by the fragment
+	// and reorder dialers and ignored by this one -- a strategy that raced a
+	// forced dialer against an unforced one. It also hid the tls handshake,
+	// which is where a blackholed path actually fails.
+	//
+	// The cost is that ConnectTimeout and TlsTimeout are now separate budgets
+	// rather than one deadline shared across connect and handshake. That is
+	// the intended behavior, and it applies to every dial, not only forced
+	// ones.
 
 	return func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		// the handshake half of the dial. It does NOT close the connection it
+		// was handed on its own error paths -- dialControlTlsWithFamilyFallback
+		// owns that connection, because it has to read the family off it before
+		// it goes away.
+		handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+			netDialer := settings.NetDialer()
+			if netDialer.Timeout != 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, netDialer.Timeout)
+				defer cancel()
+			}
+			if !netDialer.Deadline.IsZero() {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, netDialer.Deadline)
+				defer cancel()
+			}
+
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+
+			config := tlsConfig.Clone()
+			if config.ServerName == "" {
+				config.ServerName = host
+			}
+			tlsConn := tls.Client(conn, config)
+			tlsCtx, tlsCancel := context.WithTimeout(ctx, settings.TlsTimeout)
+			defer tlsCancel()
+			if err := tlsConn.HandshakeContext(tlsCtx); err != nil {
+				tlsConn.Close()
+				return nil, err
+			}
+			return tlsConn, nil
+		}
 		// DialContext preserves injected userspace networks in tests and proxy
 		// routing in production before wrapping the resulting connection in TLS.
-		conn, err := settings.DialContext(ctx, network, addr)
-		if err != nil {
-			return nil, err
-		}
-
-		netDialer := settings.NetDialer()
-		if netDialer.Timeout != 0 {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, netDialer.Timeout)
-			defer cancel()
-		}
-		if !netDialer.Deadline.IsZero() {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithDeadline(ctx, netDialer.Deadline)
-			defer cancel()
-		}
-
-		host, _, err := net.SplitHostPort(addr)
-		if err != nil {
-			conn.Close()
-			return nil, err
-		}
-
-		config := tlsConfig.Clone()
-		if config.ServerName == "" {
-			config.ServerName = host
-		}
-		tlsConn := tls.Client(conn, config)
-		tlsCtx, tlsCancel := context.WithTimeout(ctx, settings.TlsTimeout)
-		defer tlsCancel()
-		if err := tlsConn.HandshakeContext(tlsCtx); err != nil {
-			tlsConn.Close()
-			return nil, err
-		}
-		return tlsConn, nil
+		return dialControlTlsWithFamilyFallback(
+			ctx, &settings.ConnectSettings, network, addr, settings.DialContext, handshake)
 	}
 }
 
@@ -1541,16 +1562,31 @@ func (self *clientDialer) HttpClient() *http.Client {
 			// multiplexes those requests over the established connection.
 			ForceAttemptHTTP2: true,
 		}
+		// A control-plane connection that went dark AFTER connecting is
+		// invisible to any dial-time policy: http/2 multiplexes every later
+		// request onto it and each one hangs to the request timeout, for as
+		// long as the idle pool holds it. Go performs NO health check when
+		// SendPingTimeout is zero (net/http.HTTP2Config: "If zero, no health
+		// check is performed"), which is what leaves that connection in the
+		// pool. The ping is what turns a silent pool poisoning into an
+		// eviction.
+		//
+		// Built unconditionally. The memory-budget fields below are set only
+		// when an embedder asked for them -- that guard is about the mobile
+		// heap -- but it used to gate the whole config, so a desktop build had
+		// no HTTP2Config at all and therefore no health check either.
+		transport.HTTP2 = &http.HTTP2Config{
+			SendPingTimeout: self.settings.Http2SendPingTimeout,
+			PingTimeout:     self.settings.Http2PingTimeout,
+		}
 		if 0 < self.settings.Http2MaxDecoderHeaderTableSize ||
 			0 < self.settings.Http2MaxEncoderHeaderTableSize ||
 			0 < self.settings.Http2MaxReceiveBufferPerConnection ||
 			0 < self.settings.Http2MaxReceiveBufferPerStream {
-			transport.HTTP2 = &http.HTTP2Config{
-				MaxDecoderHeaderTableSize:     self.settings.Http2MaxDecoderHeaderTableSize,
-				MaxEncoderHeaderTableSize:     self.settings.Http2MaxEncoderHeaderTableSize,
-				MaxReceiveBufferPerConnection: self.settings.Http2MaxReceiveBufferPerConnection,
-				MaxReceiveBufferPerStream:     self.settings.Http2MaxReceiveBufferPerStream,
-			}
+			transport.HTTP2.MaxDecoderHeaderTableSize = self.settings.Http2MaxDecoderHeaderTableSize
+			transport.HTTP2.MaxEncoderHeaderTableSize = self.settings.Http2MaxEncoderHeaderTableSize
+			transport.HTTP2.MaxReceiveBufferPerConnection = self.settings.Http2MaxReceiveBufferPerConnection
+			transport.HTTP2.MaxReceiveBufferPerStream = self.settings.Http2MaxReceiveBufferPerStream
 		}
 		// a custom dial context applies to plain (non-tls) connections;
 		// tls connections use the dialTlsContext chain above

--- a/net_http_seam_test.go
+++ b/net_http_seam_test.go
@@ -11,8 +11,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // A direct TLS dial must use ConnectSettings.DialContext when one is supplied,
@@ -134,5 +136,112 @@ func TestClientStrategySeamDefaultsAreDisabled(t *testing.T) {
 	}
 	if settings.TlsConfig == nil || settings.TlsConfig.MinVersion < tls.VersionTLS12 {
 		t.Fatal("default strategy lost its production TLS configuration")
+	}
+}
+
+// The MOBILE configuration -- no proxy, no injected dial context -- is the one
+// that took the old fast path and bypassed ConnectSettings.DialContext
+// entirely. That bypass is why DisableIpv4/DisableIpv6 were dead: the flags
+// were honored by the fragment and reorder dialers and ignored by the default
+// one, so the strategy raced a forced dialer against an unforced one.
+//
+// The hook is on ConnectSettings.DialContext -- the seam the family policy
+// lives on -- and records the network string AFTER controlDialNetwork has
+// resolved it. That placement is what makes this test FAIL on unfixed code:
+// with the fast path still present the mobile shape returns a raw tls.Dialer
+// and never calls DialContext at all, so the hook never fires and the test
+// fails on "the seam is still bypassed".
+//
+// A hook on the net.Dialer's Control callback could not do this. Control is
+// documented to receive an already-family-specific network ("tcp4"/"tcp6"),
+// never "tcp", so against an IPv4 literal it records "tcp4" whether or not the
+// bypass was ever closed -- a guard that passes on the unfixed code it exists
+// to catch.
+//
+// The target is a NAME, not an address literal. controlDialNetwork
+// deliberately leaves a literal's network string alone -- the address already
+// fixes the family, so narrowing there can only break a working dial -- and
+// the seam this test exists to guard is the one that steers a RESOLUTION.
+func TestNormalTlsDialHonorsFamilyPolicyWithNoInjectedDialContext(t *testing.T) {
+	SetControlIpFamilyPolicy(IpFamilyForce4)
+	defer SetControlIpFamilyPolicy(IpFamilyAuto)
+
+	settings := DefaultClientStrategySettings()
+	if settings.ProxySettings != nil || settings.DialContextSettings != nil {
+		t.Fatal("the default settings are no longer the mobile shape this test pins")
+	}
+
+	var mutex sync.Mutex
+	var networks []string
+	settings.DialNetworkHook = func(network string, addr string) {
+		mutex.Lock()
+		defer mutex.Unlock()
+		networks = append(networks, network)
+	}
+
+	dialTls := newNormalDialTlsContext(settings, clientHttpNextProtos)
+	// the host is never reached: .invalid is reserved by RFC 2606 and never
+	// resolves. What is under test is the NETWORK STRING the seam resolved,
+	// which is recorded before the dial is attempted.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, err := dialTls(ctx, "tcp", "family-seam.invalid:443")
+	if err == nil {
+		conn.Close()
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	if len(networks) == 0 {
+		t.Fatal("ConnectSettings.DialContext was never called -- the seam is still bypassed")
+	}
+	if len(networks) != 1 || networks[0] != "tcp4" {
+		t.Fatalf("resolved %v, want exactly [tcp4] under IpFamilyForce4", networks)
+	}
+}
+
+// A pooled connection that connected cleanly and later went dark is invisible
+// to any dial-time logic: http/2 multiplexes every later request onto it, and
+// with no health check each one hangs to the request timeout. Go's default for
+// HTTP2Config.SendPingTimeout is zero, which its own doc defines as "no health
+// check is performed".
+//
+// This also pins that the config is built on EVERY platform. It used to be
+// built only under the mobile memory guard, so desktop had no HTTP2Config at
+// all and therefore no health check either.
+func TestHttpClientConfiguresHttp2HealthCheck(t *testing.T) {
+	settings := DefaultClientStrategySettings()
+	dialer := &clientDialer{
+		dialTlsContext:     newNormalDialTlsContext(settings, clientWebSocketNextProtos),
+		httpDialTlsContext: newNormalDialTlsContext(settings, clientHttpNextProtos),
+		settings:           settings,
+	}
+	client := dialer.HttpClient()
+	defer client.CloseIdleConnections()
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("unexpected transport type %T", client.Transport)
+	}
+	if transport.HTTP2 == nil {
+		t.Fatal("no HTTP2Config: a pooled dead connection is never detected")
+	}
+	// asserted against the SETTINGS, not against bare literals: the durations
+	// are tunable fields, so a test that pinned 10s/5s directly would fail an
+	// embedder that legitimately tuned them, and would stop testing that the
+	// transport is wired to the settings at all
+	if settings.Http2SendPingTimeout <= 0 {
+		t.Fatal("the default Http2SendPingTimeout is zero, which disables the health check")
+	}
+	if settings.Http2PingTimeout <= 0 {
+		t.Fatal("the default Http2PingTimeout is zero")
+	}
+	if transport.HTTP2.SendPingTimeout != settings.Http2SendPingTimeout {
+		t.Fatalf("SendPingTimeout is %s, want the settings value %s",
+			transport.HTTP2.SendPingTimeout, settings.Http2SendPingTimeout)
+	}
+	if transport.HTTP2.PingTimeout != settings.Http2PingTimeout {
+		t.Fatalf("PingTimeout is %s, want the settings value %s",
+			transport.HTTP2.PingTimeout, settings.Http2PingTimeout)
 	}
 }

--- a/net_resilient.go
+++ b/net_resilient.go
@@ -91,36 +91,51 @@ func newResilientDialTlsContext(
 			panic(err)
 		}
 
-		// fmt.Printf("Extender client 1\n")
+		// the handshake half of the dial, split out so the address-family
+		// fallback can own the connection between the connect and the
+		// handshake -- it has to read the family off it before a failed
+		// handshake takes it away.
+		handshake := func(ctx context.Context, conn net.Conn) (net.Conn, error) {
+			rconn := NewResilientTlsConn(conn, fragment, reorder)
 
-		conn, err := connectSettings.DialContext(ctx, "tcp", addr)
-		if err != nil {
-			return nil, err
+			// copy and extend
+			tlsConfig := baseTlsConfig.Clone()
+			tlsConfig.ServerName = host
+			tlsConn := tls.Client(rconn, tlsConfig)
+
+			var err error
+			func() {
+				tlsCtx, tlsCancel := context.WithTimeout(ctx, connectSettings.TlsTimeout)
+				defer tlsCancel()
+				err = tlsConn.HandshakeContext(tlsCtx)
+			}()
+			if err != nil {
+				tlsConn.Close()
+				return nil, err
+			}
+			// once the stream is established, no longer need the resilient features
+			if err := rconn.Off(); err != nil {
+				tlsConn.Close()
+				return nil, err
+			}
+
+			return tlsConn, nil
 		}
 
-		rconn := NewResilientTlsConn(conn, fragment, reorder)
-
-		// copy and extend
-		tlsConfig := baseTlsConfig.Clone()
-		tlsConfig.ServerName = host
-		tlsConn := tls.Client(rconn, tlsConfig)
-
-		func() {
-			tlsCtx, tlsCancel := context.WithTimeout(ctx, connectSettings.TlsTimeout)
-			defer tlsCancel()
-			err = tlsConn.HandshakeContext(tlsCtx)
-		}()
-		if err != nil {
-			tlsConn.Close()
-			return nil, err
-		}
-		// once the stream is established, no longer need the resilient features
-		if err := rconn.Off(); err != nil {
-			tlsConn.Close()
-			return nil, err
-		}
-
-		return tlsConn, nil
+		// The resilient dialers need the family fallback as much as the normal
+		// one does, and wiring it into newNormalDialTlsContext alone is the
+		// wrong half to have. Api posts do not race the dialers: they go
+		// through HttpSerial -> serialEval, which sorts the dialers it has
+		// already seen succeed by priority, and "fragment" is priority 0 while
+		// "normal" is 25 -- so once a launch is warm, the fragment dialer is
+		// the FIRST one every serial post tries. Before that it is one of the
+		// dialers the parallel hello runs. Either way a post over a
+		// blackholed ipv6 path stalled here, in a dialer with no timeout
+		// classification and no strike, until serialEval's whole budget was
+		// gone -- the exact stall this feature exists to remove, and with
+		// nothing recorded to show for it.
+		return dialControlTlsWithFamilyFallback(
+			ctx, connectSettings, "tcp", addr, connectSettings.DialContext, handshake)
 	}
 }
 


### PR DESCRIPTION
Some users cannot reach the API because their ISP routes badly to the service's IPv6 address. `api.bringyour.com` and `connect.bringyour.com` both publish AAAA records in Hurricane Electric space (`2001:470::/32`).

**Go already handles the easy half.** `net.Dialer` does RFC 6555 Happy Eyeballs unconditionally for network `"tcp"`, so a *pre-connect* blackhole recovers in ~300 ms (measured: 302 ms vs 4 s with the race disabled). Nothing here changes that.

**The unhandled half is post-connect**, and it's the shape an HE tunnel produces: a 1480-byte MTU with ICMPv6 Packet-Too-Big filtered. SYN and SYN-ACK are small and pass, so **IPv6 wins the Happy Eyeballs race** — then the large TLS ServerHello is dropped and the connection stalls to the timeout. Happy Eyeballs races only the TCP handshake and cannot see this.

## What this adds

`control_family.go` — a process-global policy with two independent pieces of state: an explicit force (`Auto` / `Force4` / `Force6`) and a learned demotion ledger. `controlDialNetwork` narrows the network string; every control dial consults it.

**The demotion trigger is deliberately narrow**: only a timeout *after* a successful TCP connect. Certificate errors, ALPN mismatches, RSTs and refusals mean the packets arrived and something at the far end objected — demoting on those would blame IPv6 for a server misconfiguration.

**Backoff, not a fixed cooldown**: 5 min doubling to a 6 h cap, cleared on `NetworkChanged()`.

**A guard against self-inflicted outage**: never demote a family when the other is unusable. `probeFamilySupport` deliberately excludes this process's own tunnel interface — a VPN tun carries a global-unicast RFC1918 address, and `net.IP.IsGlobalUnicast()` is true for `10/8`, so a naive probe answers "yes, IPv4 works" on an IPv6-only device with the tunnel up. It also **fails closed** and re-validates on *use*, not only at record time, so a demotion can never be applied on a path where recording it would have been refused.

`control_family_dial.go` — dial, hand off to a handshake, and on a proven post-connect timeout record a strike and retry **once** over the other family. Exactly one retry; the original error is returned unwrapped on a second failure.

## Bug fixed along the way

`newNormalDialTlsContext` took a fast path to a raw `tls.Dialer` whenever no proxy and no injected `DialContextSettings` were configured — **precisely the mobile production shape**. That bypassed `ConnectSettings.DialContext`, so the existing `DisableIpv4`/`DisableIpv6` fields were honoured by the fragment/reorder dialers and ignored by the default one. Those fields were never set by anything and are removed here.

⚠️ **They were exported fields on an exported struct**, so an out-of-tree consumer setting them will fail to compile. No deprecation shim is included — adding API the fork never had felt like scope beyond extraction, but that's your call.

Also: `HTTP2Config.SendPingTimeout` was zero, which Go documents as "no health check is performed", so a pooled connection that went dark was never detected. Now set, and built unconditionally — the config used to be built only under the mobile memory guard, so desktop had none at all.

## Integration notes for reviewers

This is extracted onto current `main`, and five of the twelve files had moved upstream since the fork base. Each was integrated rather than overwritten:

- **`egress_dial.go`** — both sides independently made the same `net.DefaultResolver` substitution for different reasons. Kept your rationale comment verbatim alongside the feature's `bound` hoist.
- **`egress_dial_sites_test.go`** — kept your new `ice_resolve_net.go` allowlist entry, which a naive take-theirs would have dropped, and merged the two reasons for the changed key.
- **`net_http.go` / `net_resilient.go`** — disjoint regions; `preferredEvalAttemptContext`, `Close`, `CloseIdleConnections`, `isLastSuccessWithLock`, `cloneHttpRequestForAttempt`, `startWorker` and `duplicateSocketHandle` all verified present.

⚠️ **One semantic interaction worth your attention.** Your new `preferredEvalAttemptContext` gives each *serial* attempt `remaining/(n+1)` of the 15 s budget, so a serial attempt arrives with ≤7.5 s and never clears the feature's 13 s bound-plus-reserve threshold — meaning **no demotion is learned on the serial path**. Traced through: `parallelEval` still gets the full budget, and since your `IsLastSuccess` now requires `0 < successCount`, a cold strategy has an empty serial set and falls straight through to the parallel hello — so **a launch, which is the scenario this targets, still learns**. On a warm strategy it's learned one request later, after your own `dialer.Update` marks the stalled route failed. The doc comment now describes this accurately. Constants were deliberately **not** retuned — making the threshold budget-relative rather than a fixed floor is a design call for you.

## Verification

```
go build ./...   exit 0
go vet ./...     exit 0
gofmt -l         clean (all 12 files)
go test ./...    ok connect 424.842s · blocker · connectctl · extender — exit 0
```

Full suite, not a subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vN7zh8WeQYCtirhcA3aWw