### PR TITLE
transfer/p2p: a lossy WebRTC lane must not gate, stall, or storm the relay lane (pinned-provider 1 Mb/s collapse)

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -5977,16 +5977,9 @@ sendSequenceLoop:
 				// ordinary cadence. Any resend awaits fresh acknowledgement state.
 				recoveryKind := item.recoveryKind
 				item.recoveryKind = sendRecoveryNone
+				reliableOnlyResend := false
 				if recoveryKind == sendRecoveryNone && item.unreliableFlightTracked {
-					// An RTO is the only congestion evidence available for a lost
-					// tail or a lost cumulative Ack. QUIC does not retransmit the
-					// DATAGRAM payload, so its lower-layer congestion response cannot
-					// release this Transfer flight; halve admission before retrying.
-					self.client.unreliableFlightTimeoutCount.Add(1)
-					if self.flightController.reduceForLoss() {
-						self.client.unreliableFlightReductionCount.Add(1)
-					}
-					self.client.observeUnreliableFlight(self.flightController)
+					reliableOnlyResend = self.observeUnreliableResendTimeout(item, flightPolicy)
 				}
 				item.selectiveAcked = false
 
@@ -6033,6 +6026,7 @@ sendSequenceLoop:
 						resendForceUnwrapped,
 						item,
 						true,
+						reliableOnlyResend,
 					)
 					return writeErr
 				}
@@ -6098,14 +6092,20 @@ sendSequenceLoop:
 			0,
 			self.sendBufferSettings.ResendQueueMaxByteCount,
 		)
+		// The unreliable flight only gates admission while no reliable carrier
+		// can take the overflow; otherwise a full flight is written reliable-only
+		// (see writeMaybeWrappedBytes) instead of stalling the sequence.
+		flightGates := self.unreliableFlightGates(flightPolicy)
 		flightEligible := func(sendPack *SendPack) bool {
 			return flightPolicy.flowIsolation &&
 				self.noAckPackCanBypassRecoveryAdmission(sendPack) ||
+				!flightGates ||
 				self.flightController.canSendForKey(sendPack.schedulingKey)
 		}
 		sendEligible := func(sendPack *SendPack) bool {
 			return self.noAckPackCanBypassRecoveryAdmission(sendPack) ||
-				resendCapacity && self.flightController.canSendForKey(sendPack.schedulingKey)
+				resendCapacity &&
+					(!flightGates || self.flightController.canSendForKey(sendPack.schedulingKey))
 		}
 		var sendPack *SendPack
 		bypassedRecoveryAdmission := false
@@ -6306,7 +6306,7 @@ sendSequenceLoop:
 			continue
 		}
 
-		flightBlocked := self.flightController.limited &&
+		flightBlocked := flightGates &&
 			(!self.flightController.canSend() ||
 				0 < scheduler.Len() && !scheduler.HasEligible(flightEligible))
 		if flightBlocked {
@@ -7129,6 +7129,7 @@ func (self *SendSequence) sendWithSetContractRecords(
 			item.forceUnwrapped,
 			item,
 			false,
+			false,
 		)
 		return writeErr
 	}
@@ -7392,6 +7393,50 @@ func (self *SendSequence) releaseUnreliableFlight(item *sendItem) {
 	self.client.observeUnreliableFlight(self.flightController)
 }
 
+// unreliableFlightGates reports whether a full unreliable flight must stop
+// admitting packs. That is only the case when no reliable carrier is active:
+// with one, the overflow is written reliable-only instead of stalling the
+// sequence (and, on a client, its entire receive path behind it).
+func (self *SendSequence) unreliableFlightGates(
+	policy transferFlightPolicySnapshot,
+) bool {
+	return self.flightController.limited && !policy.reliableRouteAvailable
+}
+
+// reliableOnlyWrite reports whether the next write must avoid the unreliable
+// carrier because its flight is full and a reliable carrier can take it.
+func (self *SendSequence) reliableOnlyWrite(
+	policy transferFlightPolicySnapshot,
+) bool {
+	return policy.reliableRouteAvailable &&
+		self.flightController.limited &&
+		!self.flightController.canSend()
+}
+
+// observeUnreliableResendTimeout applies the RTO of an unreliable-tracked item.
+// An RTO is the only congestion evidence available for a lost tail or a lost
+// cumulative Ack. QUIC does not retransmit the DATAGRAM payload, so its
+// lower-layer congestion response cannot release this Transfer flight; halve
+// admission before retrying. When a reliable carrier is active the resend goes
+// there, so the item leaves the unreliable flight now instead of holding the
+// whole sequence until the (possibly dead) unreliable carrier acknowledges it.
+// Returns whether the resend must be written reliable-only.
+func (self *SendSequence) observeUnreliableResendTimeout(
+	item *sendItem,
+	policy transferFlightPolicySnapshot,
+) bool {
+	self.client.unreliableFlightTimeoutCount.Add(1)
+	if self.flightController.reduceForLoss() {
+		self.client.unreliableFlightReductionCount.Add(1)
+	}
+	if !policy.reliableRouteAvailable {
+		self.client.observeUnreliableFlight(self.flightController)
+		return false
+	}
+	self.releaseUnreliableFlight(item)
+	return true
+}
+
 func (self *SendSequence) receiveAck(
 	messageId Id,
 	selective bool,
@@ -7542,8 +7587,13 @@ func (self *SendSequence) writeMaybeWrappedBytes(
 	forceUnwrapped bool,
 	item *sendItem,
 	resend bool,
+	reliableOnly bool,
 ) (transferWriteDisposition, error) {
 	writer := self.openContractMultiRouteWriter()
+	// A full unreliable flight must not stall this sequence while a reliable
+	// carrier is active: route the overflow reliable-only so it is neither
+	// tracked in the flight nor lost with the unreliable carrier.
+	reliableOnly = reliableOnly || self.reliableOnlyWrite(self.transferFlightPolicy())
 	var cipher *sequenceCipher
 	if self.session != nil && !forceUnwrapped {
 		cipher = self.session.Cipher()
@@ -7591,6 +7641,7 @@ func (self *SendSequence) writeMaybeWrappedBytes(
 			self.ctx,
 			shared,
 			self.sendBufferSettings.WriteTimeout,
+			reliableOnly,
 		)
 		if err != nil {
 			// on failure (abort/timeout) no route consumer took the message, so
@@ -7631,6 +7682,7 @@ func (self *SendSequence) writeMaybeWrappedBytes(
 		self.ctx,
 		shared,
 		self.sendBufferSettings.WriteTimeout,
+		reliableOnly,
 	)
 	if err != nil {
 		// see the plaintext branch: a failed write leaves ownership here
@@ -7679,7 +7731,27 @@ func writeMultiRouteWithCarrier(
 	ctx context.Context,
 	transferFrameBytes []byte,
 	timeout time.Duration,
+	reliableOnly bool,
 ) (transferWriteDisposition, error) {
+	if reliableOnly {
+		if reliableWriter, ok := writer.(transferReliableOnlyMultiRouteWriter); ok {
+			success, disposition, err := reliableWriter.writeDetailedReliableOnly(
+				ctx,
+				transferFrameBytes,
+				timeout,
+			)
+			if err != nil {
+				return transferWriteDisposition{}, err
+			}
+			if !success {
+				return transferWriteDisposition{}, errTransferRouteWriteTimeout
+			}
+			if disposition.transportType == "" {
+				disposition.transportType = TransportTypeUnknown
+			}
+			return disposition, nil
+		}
+	}
 	if carrierWriter, ok := writer.(transferCarrierMultiRouteWriter); ok {
 		success, disposition, err := carrierWriter.writeDetailedWithCarrier(
 			ctx,

--- a/transfer.go
+++ b/transfer.go
@@ -5521,7 +5521,15 @@ func (self *SendSequence) scheduleSelectiveAckRecovery(currentTime time.Time) bo
 		if gapItem == nil {
 			gapItem = item
 		}
-		if 0 < threshold && gapRecoveryCount < burstSize &&
+		// Mixed lanes: an item carried by the reliable route is routinely
+		// acknowledged after later items that rode a direct datagram lane
+		// with a fraction of its latency. Until it is older than the reliable
+		// lane's RTT it is late, not lost; a gap resend now only doubles the
+		// relay traffic. Its own RTO still covers a real loss.
+		lateNotLost := self.flightController != nil && self.flightController.limited &&
+			item.reliableCarrierObserved && !item.unreliableFlightTracked &&
+			currentTime.Before(item.sendTime.Add(self.rttWindow.ScaledRtt()))
+		if 0 < threshold && gapRecoveryCount < burstSize && !lateNotLost &&
 			!item.selectiveGapRecovered &&
 			(item.ackTailProbeCount == 0 || item.recoveryKind != sendRecoveryNone) &&
 			threshold <= remainingSelectiveAckCount {
@@ -7404,6 +7412,20 @@ func (self *SendSequence) releaseUnreliableFlight(item *sendItem) {
 // admitting packs. That is only the case when no reliable carrier is active:
 // with one, the overflow is written reliable-only instead of stalling the
 // sequence (and, on a client, its entire receive path behind it).
+// observeAckRtt feeds the sequence's RTT window from an acknowledged item,
+// except for items carried by an unreliable lane. A direct datagram lane
+// answers in ~20 ms while the relay carrier takes 150-300 ms; mixing both into
+// one window drags the scaled RTO down to its floor and every relay-carried
+// item is resent before its ACK can arrive (thousands of spurious timeout
+// resends per second while p2p is live). The unreliable lane has its own
+// bounded recovery policy and does not depend on this estimate.
+func (self *SendSequence) observeAckRtt(item *sendItem, tag sequenceTag) {
+	if !tag.set || item == nil || item.unreliableCarrierObserved {
+		return
+	}
+	self.rttWindow.CloseSendTime(tag.sendTime)
+}
+
 func (self *SendSequence) unreliableFlightGates(
 	policy transferFlightPolicySnapshot,
 ) bool {
@@ -7467,9 +7489,7 @@ func (self *SendSequence) receiveAck(
 		return
 	}
 
-	if tag.set {
-		self.rttWindow.CloseSendTime(tag.sendTime)
-	}
+	self.observeAckRtt(item, tag)
 
 	if selective {
 		if self.log.V(1).Enabled() {

--- a/transfer.go
+++ b/transfer.go
@@ -747,6 +747,7 @@ func DefaultSendBufferSettingsWithBufferSize(bufferSize int) *SendBufferSettings
 		// one fully acknowledged window adds about this much capacity.
 		UnreliableFlightIncreaseByteCount:    1150,
 		UnreliableFlightIncreaseMessageCount: 1,
+		UnreliableFloorSingleFlight:          false,
 		SequenceBufferSize:                   bufferSize,
 		AckBufferSize:                        bufferSize,
 		MinMessageByteCount:                  ByteCount(1),
@@ -3753,6 +3754,12 @@ type SendBufferSettings struct {
 	UnreliableMinimumFlightMessageCount  int
 	UnreliableMaximumFlightMessageCount  int
 	UnreliableFlightIncreaseMessageCount int
+	// UnreliableFloorSingleFlight keeps at most one message in flight on an
+	// unreliable carrier whose flight limit has collapsed to its floor after
+	// repeated loss, while a reliable carrier takes everything else. The lossy
+	// lane still proves itself with that one message (an ACK reopens growth)
+	// but no longer stripes an ordered stream with a carrier that drops it.
+	UnreliableFloorSingleFlight bool
 
 	SequenceBufferSize int
 	AckBufferSize      int
@@ -7408,9 +7415,17 @@ func (self *SendSequence) unreliableFlightGates(
 func (self *SendSequence) reliableOnlyWrite(
 	policy transferFlightPolicySnapshot,
 ) bool {
-	return policy.reliableRouteAvailable &&
-		self.flightController.limited &&
-		!self.flightController.canSend()
+	if !policy.reliableRouteAvailable || !self.flightController.limited {
+		return false
+	}
+	if !self.flightController.canSend() {
+		return true
+	}
+	// A carrier that loss has reduced to its floor keeps proving itself with
+	// a single message in flight; the ordered stream is not striped onto it.
+	return self.sendBufferSettings.UnreliableFloorSingleFlight &&
+		self.flightController.atFloor() &&
+		0 < self.flightController.messageCount
 }
 
 // observeUnreliableResendTimeout applies the RTO of an unreliable-tracked item.
@@ -9582,7 +9597,7 @@ func (self *ReceiveSequence) Run() {
 					} else if sendAck.transportType != TransportTypeUnknown {
 						var success bool
 						var disposition transferWriteDisposition
-						success, disposition, writeErr = selector.writeDetailedWithCarrierPreference(
+						success, disposition, writeErr = selector.writeDetailedReplyWithCarrierPreference(
 							ackWriteCtx,
 							shared,
 							self.receiveBufferSettings.WriteTimeout,

--- a/transfer_flight.go
+++ b/transfer_flight.go
@@ -325,3 +325,16 @@ func (self *sendFlightController) reduceForLoss() bool {
 	}
 	return reduced
 }
+
+// atFloor reports whether loss reductions have pinned the unreliable flight
+// limit to its minimum: the carrier is currently proving unable to sustain
+// more than the floor, so striping an ordered stream onto it only reorders it.
+func (self *sendFlightController) atFloor() bool {
+	if !self.limited || self.slowStart {
+		return false
+	}
+	if self.byteLimit <= self.activeMinimumByteCount {
+		return true
+	}
+	return 0 < self.messageLimit && self.messageLimit <= self.activeMinimumMessageCount
+}

--- a/transfer_flight_fallback_test.go
+++ b/transfer_flight_fallback_test.go
@@ -245,3 +245,66 @@ func TestMultiRouteSelectorReplyAvoidsUnreliableCarrier(t *testing.T) {
 		t.Fatalf("p2p-only reply: success=%t disposition=%+v err=%v", success, disposition, err)
 	}
 }
+
+// Acks for unreliable-carried items must not feed the sequence RTT window.
+func TestSendSequenceAckRttIgnoresUnreliableCarrier(t *testing.T) {
+	settings := DefaultSendBufferSettings()
+	sequence := testUnreliableRecoverySequence(settings)
+	sequence.client = &Client{}
+	sequence.flightController = newSendFlightController(settings)
+	sequence.flightController.applyPolicy(transferFlightPolicySnapshot{generation: 1, limited: true, reliableRouteAvailable: true})
+	before := sequence.rttWindow.ScaledRtt()
+
+	unreliableItem := &sendItem{transferFrameBytes: make([]byte, 64)}
+	sequence.observeCarrierWrite(unreliableItem, transferWriteDisposition{unreliable: true})
+	tag := sequenceTag{sendTime: uint64(time.Now().Add(-5 * time.Second).UnixMilli()), set: true}
+	sequence.observeAckRtt(unreliableItem, tag)
+	if after := sequence.rttWindow.ScaledRtt(); after != before {
+		t.Fatalf("unreliable-carrier ack moved the RTT window: %s -> %s", before, after)
+	}
+
+	reliableItem := &sendItem{transferFrameBytes: make([]byte, 64)}
+	sequence.observeCarrierWrite(reliableItem, transferWriteDisposition{reliable: true})
+	sequence.observeAckRtt(reliableItem, tag)
+	if after := sequence.rttWindow.ScaledRtt(); after <= before {
+		t.Fatalf("reliable-carrier ack did not move the RTT window: %s -> %s", before, after)
+	}
+}
+
+// With a datagram lane active, a reliable-carried item that is not yet older
+// than the reliable lane's RTT is late, not lost: no gap resend for it.
+func TestSelectiveAckGapSkipsReliableItemsNotYetLateInMixedLanes(t *testing.T) {
+	sendTime := time.Unix(1_700_000_000, 0)
+	currentTime := sendTime.Add(100 * time.Millisecond)
+	sequence, items := newSelectiveAckRecoveryTestSequence(8, sendTime)
+	sequence.client = &Client{}
+	sequence.flightController = newSendFlightController(sequence.sendBufferSettings)
+	sequence.flightController.applyPolicy(transferFlightPolicySnapshot{generation: 1, limited: true, reliableRouteAvailable: true})
+	// items 0 and 4 are gaps; 0 rode the reliable lane 100 ms ago, 4 rode it long ago
+	items[0].reliableCarrierObserved = true
+	items[4].reliableCarrierObserved = true
+	items[4].sendTime = sendTime.Add(-5 * time.Second)
+	for _, index := range []int{1, 2, 3, 5, 6, 7} {
+		items[index].selectiveAcked = true
+	}
+	sequence.scheduleSelectiveAckRecovery(currentTime)
+	if items[0].selectiveGapRecovered {
+		t.Fatal("fresh reliable-carried gap item was gap-resent behind fast-lane acks")
+	}
+	if !items[4].selectiveGapRecovered || items[4].recoveryKind != sendRecoverySelectiveGap {
+		t.Fatalf("stale reliable-carried gap item was not gap-resent: recovered=%t kind=%d", items[4].selectiveGapRecovered, items[4].recoveryKind)
+	}
+
+	// single reliable lane (no unreliable carrier): behaviour unchanged
+	sequence2, items2 := newSelectiveAckRecoveryTestSequence(8, sendTime)
+	sequence2.client = &Client{}
+	sequence2.flightController = newSendFlightController(sequence2.sendBufferSettings)
+	items2[0].reliableCarrierObserved = true
+	for _, index := range []int{1, 2, 3, 5, 6, 7} {
+		items2[index].selectiveAcked = true
+	}
+	sequence2.scheduleSelectiveAckRecovery(currentTime)
+	if !items2[0].selectiveGapRecovered {
+		t.Fatal("single-lane gap recovery regressed")
+	}
+}

--- a/transfer_flight_fallback_test.go
+++ b/transfer_flight_fallback_test.go
@@ -1,0 +1,161 @@
+package connect
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// A full unreliable flight must not stall a sequence that still has a
+// reliable carrier: the overflow is written reliable-only instead.
+
+func TestRouteSnapshotReliableOnlyWritesExcludeUnreliableCarrier(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	selector := NewMultiRouteSelector(ctx, "reliable-only", nil, TransferPath{}, true)
+	defer selector.Close()
+
+	h1Transport := NewSendGatewayTransportWithType(TransportTypeH1)
+	h1Route := make(Route, 16)
+	selector.updateTransportWithProperties(h1Transport, []Route{h1Route}, TransferCarrierProperties{})
+
+	if policy := selector.transferFlightPolicy(); !policy.reliableRouteAvailable {
+		t.Fatalf("H1-only policy = %+v, want reliable route available", policy)
+	}
+
+	p2pTransport := NewSendGatewayTransportWithType(TransportTypeP2p)
+	p2pRoute := make(Route, 16)
+	selector.updateTransportWithProperties(
+		p2pTransport,
+		[]Route{p2pRoute},
+		TransferCarrierProperties{Unreliable: true},
+	)
+
+	policy := selector.transferFlightPolicy()
+	if !policy.limited || !policy.reliableRouteAvailable {
+		t.Fatalf("mixed policy = %+v, want limited with a reliable route", policy)
+	}
+
+	// every reliable-only write lands on the reliable carrier even though the
+	// unreliable route has room and is the weighted first choice
+	for i := 0; i < 8; i++ {
+		success, disposition, err := selector.writeDetailedReliableOnly(ctx, []byte{byte(i)}, time.Second)
+		if err != nil || !success {
+			t.Fatalf("reliable-only write %d: success=%t err=%v", i, success, err)
+		}
+		if disposition.transportType != TransportTypeH1 || disposition.unreliable {
+			t.Fatalf("reliable-only write %d disposition = %+v, want H1 reliable", i, disposition)
+		}
+	}
+	if len(h1Route) != 8 || len(p2pRoute) != 0 {
+		t.Fatalf("routes after reliable-only writes: h1=%d p2p=%d, want 8/0", len(h1Route), len(p2pRoute))
+	}
+
+	// without any reliable carrier the reliable-only write falls back to the
+	// ordinary route set instead of failing
+	selector.updateTransport(h1Transport, nil)
+	if policy := selector.transferFlightPolicy(); policy.reliableRouteAvailable {
+		t.Fatalf("P2P-only policy = %+v, want no reliable route", policy)
+	}
+	success, disposition, err := selector.writeDetailedReliableOnly(ctx, []byte{9}, time.Second)
+	if err != nil || !success || disposition.transportType != TransportTypeP2p {
+		t.Fatalf("fallback write: success=%t disposition=%+v err=%v", success, disposition, err)
+	}
+	if len(p2pRoute) != 1 {
+		t.Fatalf("p2p route after fallback = %d, want 1", len(p2pRoute))
+	}
+}
+
+func TestSendSequenceFullUnreliableFlightWritesReliableOnlyInsteadOfStalling(t *testing.T) {
+	settings := DefaultSendBufferSettings()
+	settings.UnreliableInitialFlightByteCount = 512
+	settings.UnreliableMinimumFlightByteCount = 512
+	settings.UnreliableMaximumFlightByteCount = 512
+	sequence := testUnreliableRecoverySequence(settings)
+	sequence.client = &Client{}
+	sequence.flightController = newSendFlightController(settings)
+
+	withReliable := transferFlightPolicySnapshot{
+		generation:             1,
+		limited:                true,
+		reliableRouteAvailable: true,
+	}
+	sequence.flightController.applyPolicy(withReliable)
+
+	// an open flight never gates admission and never forces reliable-only writes
+	if sequence.unreliableFlightGates(withReliable) {
+		t.Fatal("open flight with a reliable route gated admission")
+	}
+	if sequence.reliableOnlyWrite(withReliable) {
+		t.Fatal("open flight forced reliable-only writes")
+	}
+
+	item := &sendItem{transferFrameBytes: make([]byte, 512)}
+	sequence.observeCarrierWrite(item, transferWriteDisposition{unreliable: true})
+	if sequence.flightController.canSend() {
+		t.Fatal("flight was not full after tracking the limit")
+	}
+
+	// a full flight with a reliable carrier: keep admitting packs, write them reliable-only
+	if sequence.unreliableFlightGates(withReliable) {
+		t.Fatal("full flight gated admission although a reliable route is available")
+	}
+	if !sequence.reliableOnlyWrite(withReliable) {
+		t.Fatal("full flight did not force reliable-only writes")
+	}
+
+	// a full flight with only unreliable carriers keeps the original gate
+	unreliableOnly := transferFlightPolicySnapshot{generation: 2, limited: true}
+	sequence.flightController.applyPolicy(unreliableOnly)
+	sequence.observeCarrierWrite(&sendItem{transferFrameBytes: make([]byte, 512)}, transferWriteDisposition{unreliable: true})
+	if !sequence.unreliableFlightGates(unreliableOnly) {
+		t.Fatal("full flight without a reliable route did not gate admission")
+	}
+	if sequence.reliableOnlyWrite(unreliableOnly) {
+		t.Fatal("reliable-only write requested without a reliable route")
+	}
+}
+
+func TestSendSequenceUnreliableResendTimeoutReleasesFlightWhenReliableRouteAvailable(t *testing.T) {
+	settings := DefaultSendBufferSettings()
+	settings.UnreliableInitialFlightByteCount = 1024
+	settings.UnreliableMinimumFlightByteCount = 1024
+	settings.UnreliableMaximumFlightByteCount = 1024
+	sequence := testUnreliableRecoverySequence(settings)
+	sequence.client = &Client{}
+	sequence.flightController = newSendFlightController(settings)
+
+	unreliableOnly := transferFlightPolicySnapshot{generation: 1, limited: true}
+	sequence.flightController.applyPolicy(unreliableOnly)
+	item := &sendItem{transferFrameBytes: make([]byte, 512)}
+	sequence.observeCarrierWrite(item, transferWriteDisposition{unreliable: true})
+	if sequence.flightController.byteCount != 512 {
+		t.Fatalf("tracked flight = %d, want 512", sequence.flightController.byteCount)
+	}
+
+	// no reliable carrier: the timeout halves admission but the item stays in flight
+	if sequence.observeUnreliableResendTimeout(item, unreliableOnly) {
+		t.Fatal("resend was marked reliable-only without a reliable route")
+	}
+	if sequence.flightController.byteCount != 512 || !item.unreliableFlightTracked {
+		t.Fatalf("flight after unreliable-only timeout = %d tracked=%t, want 512/true", sequence.flightController.byteCount, item.unreliableFlightTracked)
+	}
+	stats := sequence.client.SendRecoveryStats()
+	if stats.UnreliableFlightTimeoutCount != 1 {
+		t.Fatalf("timeout count = %d, want 1", stats.UnreliableFlightTimeoutCount)
+	}
+
+	// a reliable carrier takes the resend: release the flight so new packs are not stalled
+	withReliable := transferFlightPolicySnapshot{generation: 2, limited: true, reliableRouteAvailable: true}
+	sequence.flightController.applyPolicy(withReliable)
+	if !sequence.observeUnreliableResendTimeout(item, withReliable) {
+		t.Fatal("resend was not marked reliable-only with a reliable route")
+	}
+	if sequence.flightController.byteCount != 0 || item.unreliableFlightTracked {
+		t.Fatalf("flight after reliable-fallback timeout = %d tracked=%t, want 0/false", sequence.flightController.byteCount, item.unreliableFlightTracked)
+	}
+	if !sequence.flightController.canSend() {
+		t.Fatal("flight stayed closed after the timed-out item was released")
+	}
+}

--- a/transfer_flight_fallback_test.go
+++ b/transfer_flight_fallback_test.go
@@ -159,3 +159,89 @@ func TestSendSequenceUnreliableResendTimeoutReleasesFlightWhenReliableRouteAvail
 		t.Fatal("flight stayed closed after the timed-out item was released")
 	}
 }
+
+func TestSendSequenceFloorSingleFlightKeepsOneMessageOnLossyCarrier(t *testing.T) {
+	settings := DefaultSendBufferSettings()
+	settings.UnreliableInitialFlightByteCount = 2048
+	settings.UnreliableMinimumFlightByteCount = 1024
+	settings.UnreliableMaximumFlightByteCount = 4096
+	settings.UnreliableInitialFlightMessageCount = 8
+	settings.UnreliableMinimumFlightMessageCount = 4
+	settings.UnreliableMaximumFlightMessageCount = 16
+	settings.UnreliableFloorSingleFlight = true
+	sequence := testUnreliableRecoverySequence(settings)
+	sequence.client = &Client{}
+	sequence.flightController = newSendFlightController(settings)
+	policy := transferFlightPolicySnapshot{generation: 1, limited: true, reliableRouteAvailable: true}
+	sequence.flightController.applyPolicy(policy)
+
+	// healthy carrier (limit above the floor): the flight decides alone
+	first := &sendItem{transferFrameBytes: make([]byte, 512)}
+	sequence.observeCarrierWrite(first, transferWriteDisposition{unreliable: true})
+	if sequence.flightController.atFloor() || sequence.reliableOnlyWrite(policy) {
+		t.Fatalf("healthy carrier forced reliable-only: floor=%t", sequence.flightController.atFloor())
+	}
+
+	// repeated loss pins the limit to the floor: one message may stay in
+	// flight, everything else goes reliable-only
+	for i := 0; i < 8; i++ {
+		sequence.flightController.reduceForLoss()
+	}
+	if !sequence.flightController.atFloor() {
+		t.Fatalf("flight not at floor after reductions: %d/%d", sequence.flightController.byteLimit, sequence.flightController.activeMinimumByteCount)
+	}
+	if !sequence.reliableOnlyWrite(policy) {
+		t.Fatal("floor carrier with a message in flight did not force reliable-only")
+	}
+	sequence.releaseUnreliableFlight(first)
+	if sequence.reliableOnlyWrite(policy) {
+		t.Fatal("floor carrier with an empty flight refused its single probe message")
+	}
+
+	// the rule is opt-in: without it only a full flight forces reliable-only
+	settings.UnreliableFloorSingleFlight = false
+	sequence.observeCarrierWrite(first, transferWriteDisposition{unreliable: true})
+	if sequence.reliableOnlyWrite(policy) {
+		t.Fatal("floor rule applied while disabled")
+	}
+	sequence.releaseUnreliableFlight(first)
+}
+
+// A reply keeps its carrier affinity on reliable carriers but never rides a
+// potentially unreliable one while a reliable route is active.
+func TestMultiRouteSelectorReplyAvoidsUnreliableCarrier(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	selector := NewMultiRouteSelector(ctx, "reply-affinity", nil, TransferPath{}, true)
+	defer selector.Close()
+	h1Transport := NewSendGatewayTransportWithType(TransportTypeH1)
+	h1Route := make(Route, 16)
+	selector.updateTransportWithProperties(h1Transport, []Route{h1Route}, TransferCarrierProperties{})
+	p2pTransport := NewSendGatewayTransportWithType(TransportTypeP2p)
+	p2pRoute := make(Route, 16)
+	selector.updateTransportWithProperties(p2pTransport, []Route{p2pRoute}, TransferCarrierProperties{Unreliable: true})
+
+	if !selector.transportPotentiallyUnreliable(TransportTypeP2p) || selector.transportPotentiallyUnreliable(TransportTypeH1) {
+		t.Fatal("carrier reliability classification is wrong")
+	}
+	for i := 0; i < 6; i++ {
+		success, disposition, err := selector.writeDetailedReplyWithCarrierPreference(ctx, []byte{byte(i)}, time.Second, TransportTypeP2p)
+		if err != nil || !success || disposition.transportType != TransportTypeH1 {
+			t.Fatalf("reply %d with p2p affinity: success=%t disposition=%+v err=%v; want H1", i, success, disposition, err)
+		}
+	}
+	if len(h1Route) != 6 || len(p2pRoute) != 0 {
+		t.Fatalf("routes after replies: h1=%d p2p=%d, want 6/0", len(h1Route), len(p2pRoute))
+	}
+
+	// with only the unreliable carrier the reply keeps using it
+	selector.updateTransport(h1Transport, nil)
+	if selector.transportPotentiallyUnreliable(TransportTypeP2p) {
+		t.Fatal("p2p flagged unreliable-replaceable without a reliable route")
+	}
+	success, disposition, err := selector.writeDetailedReplyWithCarrierPreference(ctx, []byte{9}, time.Second, TransportTypeP2p)
+	if err != nil || !success || disposition.transportType != TransportTypeP2p {
+		t.Fatalf("p2p-only reply: success=%t disposition=%+v err=%v", success, disposition, err)
+	}
+}

--- a/transfer_mixed_lane_regression_test.go
+++ b/transfer_mixed_lane_regression_test.go
@@ -1,0 +1,322 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/urnetwork/connect/protocol"
+)
+
+// Deterministic reproductions of the pinned-provider collapse: an ordered
+// sequence striped across a lossy unreliable lane (WebRTC datagram fast path)
+// and a reliable relay lane. Both tests drive the real Client send/receive
+// pumps through in-memory routes; nothing here depends on timing except the
+// bounded waits for a pump to act.
+
+// Builds a sender with one unreliable route and one reliable route to the same
+// peer. The unreliable flight admits exactly one byte, so the first Pack that
+// rides it fills the flight; the reliable route is unbuffered, so nothing can
+// leak onto it unless the test reads it. Resend intervals are short so a
+// timeout on the unreliable lane happens within the test.
+func newMixedLaneFlightTestClient(
+	t *testing.T,
+) (*Client, Id, Route, Route, Route, <-chan sendSequenceId) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	settings := DefaultClientSettings()
+	settings.EncryptionSettings.Mode = EncryptionModeOff
+	settings.SendBufferSettings.UnreliableInitialFlightByteCount = 1
+	settings.SendBufferSettings.UnreliableMinimumFlightByteCount = 1
+	settings.SendBufferSettings.UnreliableMaximumFlightByteCount = 1
+	settings.SendBufferSettings.UnreliableFlightIncreaseByteCount = 1
+	settings.SendBufferSettings.MinResendInterval = 100 * time.Millisecond
+	settings.SendBufferSettings.RttMinResendInterval = 100 * time.Millisecond
+	settings.SendBufferSettings.MaxResendInterval = 250 * time.Millisecond
+	settings.SendBufferSettings.UnreliableMaxResendInterval = 250 * time.Millisecond
+	client := NewClient(ctx, NewId(), NewNoContractClientOob(), settings)
+	peerId := NewId()
+	client.ContractManager().AddNoContractPeer(peerId)
+
+	unreliableRoute := make(Route, 16)
+	reliableRoute := make(Route)
+	fromPeer := make(Route, 16)
+	waits := make(chan sendSequenceId, 16)
+	client.sendBuffer.beforeResendCapacityWaitForTest = func(sequenceId sendSequenceId) {
+		select {
+		case waits <- sequenceId:
+		default:
+		}
+	}
+	client.RouteManager().UpdateTransportWithProperties(
+		NewSendGatewayTransportWithType(TransportTypeP2p),
+		[]Route{unreliableRoute},
+		TransferCarrierProperties{Unreliable: true},
+	)
+	client.RouteManager().UpdateTransportWithProperties(
+		NewSendGatewayTransportWithType(TransportTypeH1),
+		[]Route{reliableRoute},
+		TransferCarrierProperties{},
+	)
+	client.RouteManager().UpdateTransport(NewReceiveGatewayTransport(), []Route{fromPeer})
+	t.Cleanup(func() {
+		cancel()
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer closeCancel()
+		if err := client.CloseAndWait(closeCtx); err != nil {
+			t.Errorf("close mixed-lane client: %v", err)
+		}
+		for _, route := range []Route{unreliableRoute, fromPeer} {
+			for {
+				select {
+				case message := <-route:
+					MessagePoolReturn(message)
+				default:
+					goto next
+				}
+			}
+		next:
+		}
+	})
+	return client, peerId, unreliableRoute, reliableRoute, fromPeer, waits
+}
+
+// The root cause of the collapse: one unacknowledged Pack on the unreliable
+// lane filled the flight, and the flight gated every send of the sequence, so
+// a sequence with an idle reliable lane sat at zero. Now the sequence keeps
+// admitting Packs and writes them on the reliable lane only, and when the
+// unreliable Pack times out it is re-sent on the reliable lane and released
+// from the flight.
+func TestSendSequenceFullUnreliableFlightOverflowsOntoReliableLane(t *testing.T) {
+	client, peerId, unreliableRoute, reliableRoute, _, waits := newMixedLaneFlightTestClient(t)
+
+	// the first Pack rides the unreliable lane (the only route with room) and
+	// is never acknowledged, so the one-byte flight is now full
+	sendTransferFlightTestMessage(t, client, peerId, 0)
+	takeTransferFlightTestPack(t, unreliableRoute)
+
+	// Every later message must still be delivered. On stock the full flight
+	// gates every send of the sequence: the reliable lane sits idle, the
+	// resend-capacity barrier fires, and nothing else is delivered — the
+	// "1 Mb/s / 0 and never recovers" collapse.
+	//
+	// Accounting is by message content, never by Pack sequence number: Packs
+	// coalesce several messages, a head Pack can carry no application frame at
+	// all, and a retransmit repeats a sequence number with different contents.
+	const overflowCount = 4
+	pending := map[string]bool{}
+	for i := 1; i <= overflowCount; i++ {
+		sendTransferFlightTestMessage(t, client, peerId, i)
+		pending[fmt.Sprintf("flight-%d", i)] = true
+	}
+	onReliableLane := map[string]bool{}
+	collect := func(pack *protocol.Pack, reliable bool) {
+		for _, frame := range pack.GetFrames() {
+			message, err := FromFrame(frame)
+			if err != nil {
+				continue
+			}
+			simple, ok := message.(*protocol.SimpleMessage)
+			if !ok {
+				continue
+			}
+			delete(pending, simple.Content)
+			if reliable {
+				onReliableLane[simple.Content] = true
+			}
+		}
+	}
+	deadline := time.After(30 * time.Second)
+	for 0 < len(pending) {
+		select {
+		case transferFrameBytes := <-reliableRoute:
+			collect(decodeTransferFlightTestPack(t, transferFrameBytes), true)
+		case transferFrameBytes := <-unreliableRoute:
+			// once the flight has room again a retransmit may ride either lane;
+			// that still counts as delivery. The regression is the stall, below.
+			collect(decodeTransferFlightTestPack(t, transferFrameBytes), false)
+		case sequenceId := <-waits:
+			t.Fatalf("sequence %v waited on the full unreliable flight although a reliable lane is active", sequenceId)
+		case <-deadline:
+			t.Fatalf("%d messages were never delivered (%v); the full unreliable flight stalled the sequence", len(pending), pending)
+		}
+	}
+	// the overflow reached the reliable lane rather than only the full one
+	if len(onReliableLane) == 0 {
+		t.Fatal("no overflow message was carried by the reliable lane")
+	}
+	if recovery := client.SendRecoveryStats(); recovery.UnreliableFlightWaitCount != 0 {
+		t.Fatalf("sequence waited on the unreliable flight %d times with a reliable lane active: %+v", recovery.UnreliableFlightWaitCount, recovery)
+	}
+}
+
+// Decodes one routed Pack and releases the pooled carrier bytes.
+func decodeTransferFlightTestPack(t *testing.T, transferFrameBytes []byte) *protocol.Pack {
+	t.Helper()
+	defer MessagePoolReturn(transferFrameBytes)
+	var transferFrame protocol.TransferFrame
+	if err := ProtoUnmarshal(transferFrameBytes, &transferFrame); err != nil {
+		t.Fatalf("decode TransferFrame: %v", err)
+	}
+	if transferFrame.Pack != nil {
+		return transferFrame.Pack
+	}
+	frame := transferFrame.GetFrame()
+	if frame == nil || frame.GetMessageType() != protocol.MessageType_TransferPack {
+		t.Fatalf("route carried %v, want Transfer Pack", frame)
+	}
+	pack := &protocol.Pack{}
+	if err := ProtoUnmarshal(frame.MessageBytes, pack); err != nil {
+		t.Fatalf("decode Pack: %v", err)
+	}
+	return pack
+}
+
+// The second penalty: a receiver replied to Packs that arrived on the
+// unreliable lane with ACKs on that same lane, where the provider's UDP socket
+// dropped them and every lost cumulative ACK timed out the sender's whole
+// window. An ACK for an unreliable-carried Pack must leave on the reliable
+// lane while one is active.
+func TestReceiveSequenceAcksUnreliableCarriedPacksOnReliableLane(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	settings := DefaultClientSettings()
+	settings.EncryptionSettings.Mode = EncryptionModeOff
+	client := NewClient(ctx, NewId(), NewNoContractClientOob(), settings)
+	peerId := NewId()
+	client.ContractManager().AddNoContractPeer(peerId)
+
+	unreliableOut := make(Route, 16)
+	reliableOut := make(Route, 16)
+	unreliableIn := make(Route, 16)
+	client.RouteManager().UpdateTransportWithProperties(
+		NewSendGatewayTransportWithType(TransportTypeP2p),
+		[]Route{unreliableOut},
+		TransferCarrierProperties{Unreliable: true},
+	)
+	client.RouteManager().UpdateTransportWithProperties(
+		NewSendGatewayTransportWithType(TransportTypeH1),
+		[]Route{reliableOut},
+		TransferCarrierProperties{},
+	)
+	client.RouteManager().UpdateTransportWithProperties(
+		NewReceiveGatewayTransportWithType(TransportTypeP2p),
+		[]Route{unreliableIn},
+		TransferCarrierProperties{Unreliable: true},
+	)
+	t.Cleanup(func() {
+		cancel()
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer closeCancel()
+		if err := client.CloseAndWait(closeCtx); err != nil {
+			t.Errorf("close ack-lane client: %v", err)
+		}
+		for _, route := range []Route{unreliableOut, reliableOut, unreliableIn} {
+			for {
+				select {
+				case message := <-route:
+					MessagePoolReturn(message)
+				default:
+					goto next
+				}
+			}
+		next:
+		}
+	})
+
+	received := make(chan struct{}, 1)
+	client.AddReceiveCallback(func(source TransferPath, frames []*protocol.Frame, peer Peer) {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+	})
+
+	// one Pack from the peer arrives on the unreliable lane
+	frame, err := ToFrame(&protocol.SimpleMessage{Content: "via-unreliable"}, DefaultProtocolVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	messageId := NewId()
+	sequenceId := NewId()
+	packBytes, err := ProtoMarshal(&protocol.TransferFrame{
+		TransferPath: TransferPath{
+			SourceId:      peerId,
+			DestinationId: client.ClientId(),
+		}.ToProtobuf(),
+		Pack: &protocol.Pack{
+			MessageId:      messageId.Bytes(),
+			SequenceId:     sequenceId.Bytes(),
+			SequenceNumber: 0,
+			Head:           true,
+			Frames:         []*protocol.Frame{frame},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case unreliableIn <- packBytes:
+	case <-time.After(5 * time.Second):
+		t.Fatal("could not deliver the Pack")
+	}
+	select {
+	case <-received:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the Pack was not delivered to the receive callback")
+	}
+
+	// its ACK must ride the reliable lane; the client's own outbound frames
+	// (e.g. its key exchange to the peer) may use either lane and are ignored
+	isAck := func(transferFrameBytes []byte) (bool, *protocol.Ack) {
+		var transferFrame protocol.TransferFrame
+		if err := ProtoUnmarshal(transferFrameBytes, &transferFrame); err != nil {
+			t.Fatalf("decode frame: %v", err)
+		}
+		if ack := transferFrame.GetAck(); ack != nil {
+			return true, ack
+		}
+		frame := transferFrame.GetFrame()
+		if frame == nil || frame.GetMessageType() != protocol.MessageType_TransferAck {
+			return false, nil
+		}
+		ack := &protocol.Ack{}
+		if err := ProtoUnmarshal(frame.MessageBytes, ack); err != nil {
+			t.Fatalf("decode ACK: %v", err)
+		}
+		return true, ack
+	}
+	reliableAcks := 0
+	deadline := time.After(10 * time.Second)
+	settle := time.NewTimer(time.Hour)
+	defer settle.Stop()
+	for {
+		select {
+		case transferFrameBytes := <-reliableOut:
+			ok, ack := isAck(transferFrameBytes)
+			MessagePoolReturn(transferFrameBytes)
+			if !ok {
+				continue
+			}
+			if ackMessageId, err := IdFromBytes(ack.MessageId); err != nil || ackMessageId != messageId {
+				t.Fatalf("reliable-lane ACK names message %v, want %v (err %v)", ackMessageId, messageId, err)
+			}
+			reliableAcks++
+			if reliableAcks == 1 {
+				// give any stray copy time to appear on the unreliable lane
+				settle.Reset(300 * time.Millisecond)
+			}
+		case transferFrameBytes := <-unreliableOut:
+			ok, _ := isAck(transferFrameBytes)
+			MessagePoolReturn(transferFrameBytes)
+			if ok {
+				t.Fatal("an ACK for an unreliable-carried Pack was written to the unreliable lane")
+			}
+		case <-settle.C:
+			return
+		case <-deadline:
+			t.Fatal("no ACK was written on the reliable lane")
+		}
+	}
+}

--- a/transfer_route_manager.go
+++ b/transfer_route_manager.go
@@ -2727,6 +2727,58 @@ func (self *MultiRouteSelector) writeDetailedReliableOnly(
 	)
 }
 
+// writeDetailedReplyWithCarrierPreference writes a reply (an ACK) with the
+// carrier affinity of the packet it answers, except that a reply is never
+// pinned to a potentially unreliable carrier while a reliable one is active.
+// A cumulative ACK lost on a lossy datagram lane times out the sender's whole
+// window; on the reliable carrier it costs one extra hop of latency.
+func (self *MultiRouteSelector) writeDetailedReplyWithCarrierPreference(
+	ctx context.Context,
+	transferFrameBytes []byte,
+	timeout time.Duration,
+	preferredTransportType TransportType,
+) (bool, transferWriteDisposition, error) {
+	if self.transportPotentiallyUnreliable(preferredTransportType) {
+		return self.writeDetailedWithRoutePolicy(
+			ctx,
+			transferFrameBytes,
+			timeout,
+			TransportTypeUnknown,
+			true,
+		)
+	}
+	return self.writeDetailedWithRoutePolicy(
+		ctx,
+		transferFrameBytes,
+		timeout,
+		preferredTransportType,
+		false,
+	)
+}
+
+// transportPotentiallyUnreliable reports whether every active route of the
+// transport type is a potentially unreliable carrier and a reliable route
+// exists to take its place.
+func (self *MultiRouteSelector) transportPotentiallyUnreliable(
+	transportType TransportType,
+) bool {
+	snapshot := self.activeRoutesSnapshot.Load()
+	if snapshot == nil || len(snapshot.reliableRoutes) == 0 {
+		return false
+	}
+	found := false
+	for _, route := range snapshot.routes {
+		if snapshot.routeTransportTypes[route] != transportType {
+			continue
+		}
+		if !snapshot.routeCarrierProperties[route].Unreliable {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
 func (self *MultiRouteSelector) writeDetailedWithRoutePolicy(
 	ctx context.Context,
 	transferFrameBytes []byte,

--- a/transfer_route_manager.go
+++ b/transfer_route_manager.go
@@ -369,6 +369,17 @@ type transferCarrierMultiRouteWriter interface {
 	) (bool, transferWriteDisposition, error)
 }
 
+// transferReliableOnlyMultiRouteWriter writes on the active carriers that are
+// not potentially unreliable. When none exist the write uses the ordinary
+// route set, so a sequence never loses a route it could otherwise use.
+type transferReliableOnlyMultiRouteWriter interface {
+	writeDetailedReliableOnly(
+		ctx context.Context,
+		transferFrameBytes []byte,
+		timeout time.Duration,
+	) (bool, transferWriteDisposition, error)
+}
+
 type transferCarrierRouteStateProvider interface {
 	transferRouteActive(route Route) bool
 }
@@ -1539,12 +1550,15 @@ type routeSnapshot struct {
 	// can share affinity without allocating on the write path.
 	affinityWriteRoutesByTransport map[TransportType][]Route
 	routeCarrierProperties         map[Route]TransferCarrierProperties
-	generation                     uint64
-	unreliableTransferPath         bool
-	unreliableFlightByteLimit      ByteCount
-	unreliableFlightMessageLimit   int
-	unreliableFlowIsolation        bool
-	unreliableFlowReserve          bool
+	// reliableRoutes is the subset of routes whose carrier is not potentially
+	// unreliable, in route order. Reliable-only writes use it when non-empty.
+	reliableRoutes               []Route
+	generation                   uint64
+	unreliableTransferPath       bool
+	unreliableFlightByteLimit    ByteCount
+	unreliableFlightMessageLimit int
+	unreliableFlowIsolation      bool
+	unreliableFlowReserve        bool
 	// h1Only is true only when every currently active writer route is an H1
 	// carrier. Transfer uses it to recover H1's larger WebSocket message
 	// envelope without making an H3 DATAGRAM candidate exceed one tunnel MTU.
@@ -1613,21 +1627,26 @@ type transferFlightPolicySnapshot struct {
 	flowIsolation bool
 	flowReserve   bool
 	h1Only        bool
-	notify        <-chan struct{}
+	// reliableRouteAvailable is true while at least one active carrier is not
+	// potentially unreliable. A full unreliable flight then writes the
+	// overflow reliable-only instead of gating the whole sequence.
+	reliableRouteAvailable bool
+	notify                 <-chan struct{}
 }
 
 // Reads the current carrier policy without taking the selector state lock.
 func (self *MultiRouteSelector) transferFlightPolicy() transferFlightPolicySnapshot {
 	snapshot := self.activeRoutesSnapshot.Load()
 	return transferFlightPolicySnapshot{
-		generation:    snapshot.generation,
-		limited:       snapshot.unreliableTransferPath,
-		byteLimit:     snapshot.unreliableFlightByteLimit,
-		messageLimit:  snapshot.unreliableFlightMessageLimit,
-		flowIsolation: snapshot.unreliableFlowIsolation,
-		flowReserve:   snapshot.unreliableFlowReserve,
-		h1Only:        snapshot.h1Only,
-		notify:        snapshot.notify,
+		generation:             snapshot.generation,
+		limited:                snapshot.unreliableTransferPath,
+		byteLimit:              snapshot.unreliableFlightByteLimit,
+		messageLimit:           snapshot.unreliableFlightMessageLimit,
+		flowIsolation:          snapshot.unreliableFlowIsolation,
+		flowReserve:            snapshot.unreliableFlowReserve,
+		h1Only:                 snapshot.h1Only,
+		reliableRouteAvailable: 0 < len(snapshot.reliableRoutes),
+		notify:                 snapshot.notify,
 	}
 }
 
@@ -1742,6 +1761,42 @@ func (self *routeSnapshot) writeRoutes() []Route {
 		return self.routes[:1]
 	}
 	return self.shuffled()
+}
+
+// writeRoutesReliableOnly excludes every potentially unreliable carrier. With
+// no reliable carrier active it degrades to the ordinary write set rather than
+// refusing the write.
+func (self *routeSnapshot) writeRoutesReliableOnly() []Route {
+	n := len(self.reliableRoutes)
+	if n == 0 {
+		return self.writeRoutes()
+	}
+	if self.preferDirectRoute != nil && !self.routeCarrierProperties[self.preferDirectRoute].Unreliable {
+		return []Route{self.preferDirectRoute}
+	}
+	if n == 1 {
+		return self.reliableRoutes
+	}
+	routes := make([]Route, n)
+	copy(routes, self.reliableRoutes)
+	if self.weight != nil {
+		WeightedShuffle(routes, self.weight)
+	} else {
+		mathrand.Shuffle(n, func(i int, j int) {
+			routes[i], routes[j] = routes[j], routes[i]
+		})
+	}
+	return routes
+}
+
+func (self *routeSnapshot) writeRoutesFor(
+	preferredTransportType TransportType,
+	reliableOnly bool,
+) []Route {
+	if reliableOnly {
+		return self.writeRoutesReliableOnly()
+	}
+	return self.writeRoutesForTransport(preferredTransportType)
 }
 
 // writeRoutesForTransport keeps a reply eligible for every active carrier of
@@ -1909,6 +1964,7 @@ func (self *MultiRouteSelector) updateActiveRoutesWithLock() {
 	activeRoutesByTransport := map[TransportType][]Route{}
 	routePriorities := map[Route]int{}
 	routeCarrierProperties := map[Route]TransferCarrierProperties{}
+	reliableRoutes := []Route{}
 	unreliableTransferPath := false
 	unreliableFlightByteLimit := ByteCount(0)
 	unreliableFlightMessageLimit := 0
@@ -1933,6 +1989,9 @@ func (self *MultiRouteSelector) updateActiveRoutesWithLock() {
 				)
 				routePriorities[route] = transport.Priority()
 				routeCarrierProperties[route] = self.transportProperties[transport]
+				if !self.transportProperties[transport].Unreliable {
+					reliableRoutes = append(reliableRoutes, route)
+				}
 				switch transportType {
 				case TransportTypeH1:
 					hasH1 = true
@@ -2073,6 +2132,7 @@ func (self *MultiRouteSelector) updateActiveRoutesWithLock() {
 		routeTransportTypes:            routeTransportTypes,
 		affinityWriteRoutesByTransport: affinityWriteRoutesByTransport,
 		routeCarrierProperties:         routeCarrierProperties,
+		reliableRoutes:                 reliableRoutes,
 		generation:                     self.nextRouteGeneration,
 		unreliableTransferPath:         unreliableTransferPath,
 		unreliableFlightByteLimit:      unreliableFlightByteLimit,
@@ -2644,6 +2704,36 @@ func (self *MultiRouteSelector) writeDetailedWithCarrierPreference(
 	timeout time.Duration,
 	preferredTransportType TransportType,
 ) (bool, transferWriteDisposition, error) {
+	return self.writeDetailedWithRoutePolicy(
+		ctx,
+		transferFrameBytes,
+		timeout,
+		preferredTransportType,
+		false,
+	)
+}
+
+func (self *MultiRouteSelector) writeDetailedReliableOnly(
+	ctx context.Context,
+	transferFrameBytes []byte,
+	timeout time.Duration,
+) (bool, transferWriteDisposition, error) {
+	return self.writeDetailedWithRoutePolicy(
+		ctx,
+		transferFrameBytes,
+		timeout,
+		TransportTypeUnknown,
+		true,
+	)
+}
+
+func (self *MultiRouteSelector) writeDetailedWithRoutePolicy(
+	ctx context.Context,
+	transferFrameBytes []byte,
+	timeout time.Duration,
+	preferredTransportType TransportType,
+	reliableOnly bool,
+) (bool, transferWriteDisposition, error) {
 	enterTime := time.Now()
 	preferredBlockedObserved := false
 
@@ -2651,7 +2741,7 @@ func (self *MultiRouteSelector) writeDetailedWithCarrierPreference(
 	// writer selector and writes its ordered stream serially; the mutex below is
 	// only needed when a write must retain and reuse the selector timer.
 	initialSnapshot := self.acquireWriterSnapshot()
-	initialRoutes := initialSnapshot.writeRoutesForTransport(preferredTransportType)
+	initialRoutes := initialSnapshot.writeRoutesFor(preferredTransportType, reliableOnly)
 	if self.log.V(2).Enabled() {
 		self.log.Infof("[mrw] %s->%s s(%s) routes = %d\n", self.clientTag, self.destination.DestinationId, self.destination.StreamId, len(initialRoutes))
 	}
@@ -2702,7 +2792,7 @@ func (self *MultiRouteSelector) writeDetailedWithCarrierPreference(
 		// on every packet
 		snapshot := self.acquireWriterSnapshot()
 		notify := snapshot.notify
-		activeRoutes := snapshot.writeRoutesForTransport(preferredTransportType)
+		activeRoutes := snapshot.writeRoutesFor(preferredTransportType, reliableOnly)
 
 		if self.log.V(2).Enabled() {
 			self.log.Infof("[mrw] %s->%s s(%s) routes = %d\n", self.clientTag, self.destination.DestinationId, self.destination.StreamId, len(activeRoutes))

--- a/transport_p2p_udp_batch.go
+++ b/transport_p2p_udp_batch.go
@@ -24,6 +24,11 @@ type p2pUdpBatchNet struct {
 	transport.Net
 	queueSize int
 	batchSize int
+	// socketBufferByteCount, when positive, is requested as the kernel send and
+	// receive buffer of every UDP socket (the kernel clamps it to its maximum).
+	// The default ~200 KB Linux buffer overflows under fast-path bursts and
+	// drops the peer's ACKs, which times out the sender's whole window.
+	socketBufferByteCount int
 }
 
 // newP2pUdpBatchNet creates a route-neutral socket wrapper. A zero or negative
@@ -32,14 +37,31 @@ func newP2pUdpBatchNet(
 	selectedNet transport.Net,
 	queueSize int,
 	batchSize int,
+	socketBufferByteCount int,
 ) transport.Net {
 	if selectedNet == nil || queueSize <= 0 || batchSize <= 0 {
 		return selectedNet
 	}
 	return &p2pUdpBatchNet{
-		Net:       selectedNet,
-		queueSize: queueSize,
-		batchSize: min(queueSize, batchSize),
+		Net:                   selectedNet,
+		queueSize:             queueSize,
+		batchSize:             min(queueSize, batchSize),
+		socketBufferByteCount: socketBufferByteCount,
+	}
+}
+
+// applyP2pUdpSocketBuffers requests the configured kernel buffers on a socket
+// that supports them. Failures are ignored: the kernel default still works,
+// just with more loss under bursts.
+func applyP2pUdpSocketBuffers(connection any, byteCount int) {
+	if byteCount <= 0 {
+		return
+	}
+	if setter, ok := connection.(interface{ SetReadBuffer(int) error }); ok {
+		_ = setter.SetReadBuffer(byteCount)
+	}
+	if setter, ok := connection.(interface{ SetWriteBuffer(int) error }); ok {
+		_ = setter.SetWriteBuffer(byteCount)
 	}
 }
 
@@ -52,6 +74,7 @@ func (self *p2pUdpBatchNet) ListenUDP(
 	if err != nil {
 		return nil, err
 	}
+	applyP2pUdpSocketBuffers(connection, self.socketBufferByteCount)
 	return newP2pUdpBatchConn(connection, network, self.queueSize, self.batchSize), nil
 }
 
@@ -68,6 +91,7 @@ func (self *p2pUdpBatchNet) ListenPacket(
 	if !ok {
 		return connection, nil
 	}
+	applyP2pUdpSocketBuffers(udpConnection, self.socketBufferByteCount)
 	return newP2pUdpBatchConn(
 		udpConnection,
 		network,

--- a/transport_p2p_webrtc.go
+++ b/transport_p2p_webrtc.go
@@ -823,6 +823,7 @@ func DefaultWebRtcSettings() *WebRtcSettings {
 		// side. Keep roughly 24 ms of burst absorption; the queue stores pooled
 		// messages only while the route worker is actually behind.
 		DatagramFastPathReceiveBufferSize: 1024,
+		UdpSocketBufferByteCount:          int(mib(4)),
 		DatagramFastPathWriteQueueSize:    256,
 		DatagramFastPathWriteBatchSize:    64,
 		// Pion's Reno-style congestion avoidance otherwise adds one ~1.2 KiB
@@ -916,6 +917,10 @@ type WebRtcSettings struct {
 	// DatagramFastPathReceiveBufferSize bounds complete reassembled messages
 	// waiting for the route worker. Full queues drop datagrams; the inner
 	// transport recovers direct-IP loss without a second Transfer retry loop.
+	// UdpSocketBufferByteCount is requested as the kernel send and receive
+	// buffer of every ICE UDP socket; the kernel clamps it to its maximum
+	// (net.core.rmem_max/wmem_max on Linux). Zero keeps the kernel default.
+	UdpSocketBufferByteCount          int
 	DatagramFastPathReceiveBufferSize int
 	// DatagramFastPathWriteQueueSize bounds the native WebRTC socket's copied
 	// userspace send buffer. A full queue blocks the carrier writer, preserving

--- a/transport_p2p_webrtc_pc.go
+++ b/transport_p2p_webrtc_pc.go
@@ -115,6 +115,7 @@ func newWebRtcPeerConnectionFactory(
 			selectedNet,
 			settings.DatagramFastPathWriteQueueSize,
 			settings.DatagramFastPathWriteBatchSize,
+			settings.UdpSocketBufferByteCount,
 		)
 	}
 	s.DetachDataChannels()


### PR DESCRIPTION
Fixes the "pinned provider collapses to ~1 Mb/s / 0 and never recovers" report, and the throughput penalties that a live WebRTC p2p route imposes on the relay lane once the collapse is gone. Three commits, each validated on a rig (Mac socks client → platform → own provider on a VPS, pinned; 4 parallel downloads; 10 × 15 s windows; interleaved A/B against the same build without the change). Full write-up with per-round numbers is available from @Ryanmello07.

## The bug

When a p2p route (the WebRTC datagram fast path, a *potentially unreliable* carrier) joins the h1 relay route, items first carried by the p2p lane are tracked in the sequence's unreliable flight (`sendFlightController`). `canSendForKey()` gated **every** send of the sequence — h1 included — while `byteCount >= byteLimit`, and an RTO only halved the limit (floor 8 KiB / 8 messages) without releasing the lost items. On a lossy p2p carrier the limit hits its floor within seconds and the whole ordered stream is throttled to that 8 KiB window's ack rate while the relay route sits idle.

Measured on the provider's data sequence the moment p2p activated:

```
flight{lim=true b=7256/9840 m=6/6}       full (byte and message limits)
UFLIGHT waitMs ≈ 2000 / 2000 per 2 s     gated ~100 % of the time
w: 9067 -> 229..952 per 2 s              105 Mb/s -> 1.0-3.8 Mb/s
TX h1 = 72-395 / 2 s                     relay route idle
```

When the p2p data plane stops delivering entirely (fast path dies; ICE consent expires ~30 s later), the flight never drains and both ends wedge at 0 until the 30 s / 60 s ack timeouts tear the sequences down. This only happens when ICE succeeds, which is ~50 % of runs on the rig — hence the "random" reports. It is forced on for own-account pins (`ip_remote_multi_client.go` sets `AllowDirect` for `ProvideMode_Network`), which is the phone → own-VPS setup.

## Commit 1 — never let a full unreliable flight stall a sequence that has a reliable carrier

- `routeSnapshot.reliableRoutes` and `transferFlightPolicySnapshot.reliableRouteAvailable`; `MultiRouteSelector.writeDetailedReliableOnly` writes on carriers that are not potentially unreliable and degrades to the ordinary route set when there are none.
- `SendSequence.unreliableFlightGates`: the unreliable flight gates admission only when **no** reliable carrier is active.
- `SendSequence.reliableOnlyWrite`: with a reliable carrier, a full flight makes the next writes reliable-only instead of stalling.
- `SendSequence.observeUnreliableResendTimeout`: on the RTO of an unreliable-tracked item with a reliable route, the item leaves the flight and is re-sent reliable-only. Without a reliable route the previous halve-and-retry behaviour is unchanged.

The unreliable carrier keeps at most its own window; the reliable carrier carries the overflow.

⚠️ **Behaviour note:** this also applies to H3 clients (datagram lane + stream lane). A full datagram flight now overflows onto the stream/h1 lane instead of waiting for datagram acks.

Rig: stock collapsed in 5/8 runs (23/80 dead windows, all flight-gate); with this commit 0/8 flight-gate collapses. With p2p live the provider held 64–94 Mb/s where stock did 1–4 Mb/s.

## Commit 2 — keep ACKs off the unreliable lane; size the ICE UDP socket buffers

With the gate gone, a live p2p route still cost most of the throughput: the client's cumulative ACKs for p2p-delivered items were replied with p2p carrier affinity and dropped at the provider's kernel UDP receive buffer (Linux default ~208 KB; nothing in connect set `SO_RCVBUF` on the ICE sockets): `Udp6RcvbufErrors` +934 / +5,261 / +7,916 in three p2p-live runs. Each lost cumulative ACK timed out the sender's whole 2 MiB window — 1,300–5,500 timeout resends per 2 s.

- `MultiRouteSelector.writeDetailedReplyWithCarrierPreference`: a reply keeps carrier affinity on reliable carriers, but is never pinned to a potentially unreliable carrier while a reliable route is active. The `ReceiveSequence` ACK worker uses it.
- `p2pUdpBatchNet` requests `WebRtcSettings.UdpSocketBufferByteCount` (default 4 MiB) as send and receive buffer on every ICE UDP socket it wraps; the kernel clamps to `rmem_max` / `wmem_max`.
- `SendBufferSettings.UnreliableFloorSingleFlight` (**default off**): once loss has pinned an unreliable carrier's flight to its floor, keep one message in flight there and write the rest reliable-only. Harmless in 12 runs but not separable from run variance, so it ships off. Drop it if you'd rather not carry an inert knob.

Rig: `Udp6RcvbufErrors` 0 in every later p2p-live run; provider→client fast path delivering 1:1; no timeout burst above 1,000 per 2 s in the best run; 80 Mb/s mean while p2p was live.

## Commit 3 — mixed-lane recovery

With a ~20 ms direct lane and a 150–300 ms relay lane both active, every relay-carried item is routinely ACKed after three or more later direct-lane items. Selective-ACK gap recovery read that as a hole and re-sent it immediately: 1,000–2,800 gap resends per 2 s, i.e. the relay's traffic doubled by copies of packets that were only late. The same mixing fed ~20 ms ACKs into the sequence's single RTT window and dragged the scaled RTO toward its floor for relay items.

- `scheduleSelectiveAckRecovery`: while an unreliable carrier is active, a reliable-carried item not yet older than the reliable lane's scaled RTT is *late, not lost* and keeps its own RTO. Single-lane behaviour is unchanged.
- `observeAckRtt`: ACKs of unreliable-carried items no longer feed the sequence RTT window.

Rig, interleaved against commit 2 alone: gap resends while p2p was live 904 and 3,542 per run (~60 per live sample) vs ~490 per live sample without, and 32k–160k per run before commit 1.

## Known remaining issue (not in this PR)

While both lanes are live the relay lane still shows periodic whole-window timeout bursts (spurious RTO under queue-inflated RTT). A candidate (defer a reliable item's RTO resend by one scaled RTT while cumulative ACKs are still advancing) is implemented and unit-tested but has no valid A/B yet, so it is deliberately left out.

## Tests

`transfer_flight_fallback_test.go`: `TestRouteSnapshotReliableOnlyWritesExcludeUnreliableCarrier`, `TestSendSequenceFullUnreliableFlightWritesReliableOnlyInsteadOfStalling`, `TestSendSequenceUnreliableResendTimeoutReleasesFlightWhenReliableRouteAvailable`, `TestSendSequenceFloorSingleFlightKeepsOneMessageOnLossyCarrier`, `TestMultiRouteSelectorReplyAvoidsUnreliableCarrier`, `TestSendSequenceAckRttIgnoresUnreliableCarrier`, `TestSelectiveAckGapSkipsReliableItemsNotYetLateInMixedLanes`.

Plus two end-to-end regressions in `transfer_mixed_lane_regression_test.go` that drive the real `Client` send and receive pumps over in-memory routes, so they fail on `main` with the shape of the field failure rather than an internal invariant: `TestSendSequenceFullUnreliableFlightOverflowsOntoReliableLane` (on `main`: "waited on the full unreliable flight although a reliable lane is active") and `TestReceiveSequenceAcksUnreliableCarriedPacksOnReliableLane` (on `main`: "an ACK for an unreliable-carried Pack was written to the unreliable lane"). Both verified failing on current `main`.

## Verification (this branch, on current `main`)

```
go build ./...   exit 0
go vet ./...     exit 0
gofmt -l         clean
go test ./       ok github.com/urnetwork/connect 428.867s  (full suite, -count=1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GhKjxoZXQVBZnxb2mNzNL

