### PR TITLE
tun: bound the netstack outbound-queue wait so an injecting reader cannot deadlock the stack

### DIFF
--- a/tun.go
+++ b/tun.go
@@ -51,6 +51,10 @@ func DefaultTunSettings() *TunSettings {
 func DefaultTunSettingsWithBufferSize(bufferSize int) *TunSettings {
 	return &TunSettings{
 		ChannelSize: bufferSize,
+		// Far above a healthy drain interval (the reader empties a full
+		// queue in milliseconds), so ordinary bulk transfer still sees
+		// backpressure rather than drops.
+		OutboundQueueWaitTimeout: 250 * time.Millisecond,
 		// must match `DefaultMtu`. packets are written directly into the
 		// receiver tap/tun interface, so this must not exceed the device
 		// interface mtu.
@@ -110,6 +114,12 @@ type TunSettings struct {
 
 	ChannelSize int
 	Mtu         int
+	// OutboundQueueWaitTimeout bounds how long netstack waits for space in
+	// the outbound (tun read) queue before dropping the rest of a write. The
+	// queue's consumer can be inside an inbound injection itself (SendPacket
+	// -> receive callback -> Tun.Write -> gVisor reply), which would otherwise
+	// deadlock the whole stack. Non-positive waits without bound.
+	OutboundQueueWaitTimeout time.Duration
 
 	DialRace        int
 	DialRaceTimeout time.Duration
@@ -484,6 +494,14 @@ type tunLinkEndpoint struct {
 	*channel.Endpoint
 	ctx   context.Context
 	space chan struct{}
+	// waitTimeout bounds how long a netstack writer waits for outbound queue
+	// space before the rest of its batch is dropped (counted in dropCount).
+	// The goroutine that drains this queue can itself be inside an inbound
+	// injection (SendPacket -> receive callback -> Tun.Write -> gVisor reply),
+	// so an unbounded wait is a self-deadlock. Non-positive keeps the
+	// unbounded backpressure.
+	waitTimeout time.Duration
+	dropCount   atomic.Uint64
 
 	// dispatcher is the NIC's network dispatcher, captured at Attach so
 	// WriteBatch can deliver GRO-coalesced packets through the same path
@@ -505,7 +523,7 @@ func (self *tunLinkEndpoint) networkDispatcher() stack.NetworkDispatcher {
 	return self.dispatcher
 }
 
-func newTunLinkEndpoint(ctx context.Context, size int, mtu uint32, linkAddr tcpip.LinkAddress) *tunLinkEndpoint {
+func newTunLinkEndpoint(ctx context.Context, size int, mtu uint32, linkAddr tcpip.LinkAddress, waitTimeout time.Duration) *tunLinkEndpoint {
 	endpoint := channel.New(size, mtu, linkAddr)
 	// Inbound packets originate from the in-process user NAT over an
 	// authenticated tunnel, so ip/tcp checksum validation here is redundant
@@ -516,9 +534,10 @@ func newTunLinkEndpoint(ctx context.Context, size int, mtu uint32, linkAddr tcpi
 	// packet as checksum-invalid.
 	endpoint.LinkEPCapabilities |= stack.CapabilityRXChecksumOffload
 	return &tunLinkEndpoint{
-		Endpoint: endpoint,
-		ctx:      ctx,
-		space:    make(chan struct{}, 1),
+		Endpoint:    endpoint,
+		ctx:         ctx,
+		space:       make(chan struct{}, 1),
+		waitTimeout: waitTimeout,
 	}
 }
 
@@ -549,6 +568,12 @@ func (self *tunLinkEndpoint) WritePackets(packets stack.PacketBufferList) (int, 
 	packetSlice := packets.AsSlice()
 	written := 0
 	remaining := packets
+	var timer *time.Timer
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}()
 	for {
 		n, err := self.Endpoint.WritePackets(remaining)
 		written += n
@@ -566,10 +591,27 @@ func (self *tunLinkEndpoint) WritePackets(packets stack.PacketBufferList) (int, 
 			}
 		}
 
+		if self.waitTimeout <= 0 {
+			select {
+			case <-self.ctx.Done():
+				return written, &tcpip.ErrClosedForSend{}
+			case <-self.space:
+			}
+			continue
+		}
+		if timer == nil {
+			timer = time.NewTimer(self.waitTimeout)
+		}
 		select {
 		case <-self.ctx.Done():
 			return written, &tcpip.ErrClosedForSend{}
 		case <-self.space:
+		case <-timer.C:
+			// Drop the rest like a saturated NIC queue would. The caller keeps
+			// its own packet references, so nothing is released here; TCP
+			// recovers by retransmission once the queue drains.
+			self.dropCount.Add(uint64(len(packetSlice) - written))
+			return written, nil
 		}
 	}
 }
@@ -610,6 +652,7 @@ func CreateTunWithResolver(ctx context.Context, settings *TunSettings, dnsResolv
 		settings.ChannelSize,
 		uint32(settings.Mtu),
 		tcpip.LinkAddress(fmt.Sprintf("%x", nicId)),
+		settings.OutboundQueueWaitTimeout,
 	)
 
 	releaseOnError := func() {
@@ -1289,6 +1332,12 @@ func (self *Tun) Close() error {
 }
 
 // Stats returns the gVisor stack statistics for this Tun's private stack.
+// OutboundDropCount is the number of netstack packets dropped because the
+// outbound queue stayed full past OutboundQueueWaitTimeout.
+func (self *Tun) OutboundDropCount() uint64 {
+	return self.ep.dropCount.Load()
+}
+
 func (self *Tun) Stats() tcpip.Stats {
 	return self.stack.Stats()
 }

--- a/tun_outbound_wait_test.go
+++ b/tun_outbound_wait_test.go
@@ -1,0 +1,116 @@
+package connect
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// A netstack writer must never wait forever for tun queue space: the
+// goroutine that drains the queue can itself be the one injecting inbound
+// packets (socks tun reader -> SendPacket -> receive callback -> Tun.Write ->
+// gVisor reply), which is a self-deadlock when the queue is full. After the
+// bounded wait the write drops the rest and the writer returns.
+func TestTunOutboundQueueDropsAfterBoundedWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	settings := DefaultTunSettingsWithBufferSize(1)
+	settings.OutboundQueueWaitTimeout = 50 * time.Millisecond
+	tun, err := CreateTun(ctx, settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tun.Close()
+
+	firstPacket := newTunLinkTestPacket(1)
+	defer firstPacket.DecRef()
+	if result := writeTunLinkPacket(tun.ep, firstPacket); result.err != nil || result.n != 1 {
+		t.Fatalf("first link write = %d, %v; want 1, nil", result.n, result.err)
+	}
+
+	secondPacket := newTunLinkTestPacket(2)
+	defer secondPacket.DecRef()
+	start := time.Now()
+	result := writeTunLinkPacket(tun.ep, secondPacket)
+	elapsed := time.Since(start)
+	if result.err != nil || result.n != 0 {
+		t.Fatalf("full-queue link write = %d, %v; want dropped 0, nil", result.n, result.err)
+	}
+	if elapsed < settings.OutboundQueueWaitTimeout || 2*time.Second < elapsed {
+		t.Fatalf("full-queue link write took %s, want a bounded wait of about %s", elapsed, settings.OutboundQueueWaitTimeout)
+	}
+	if count := tun.OutboundDropCount(); count != 1 {
+		t.Fatalf("outbound drop count = %d, want 1", count)
+	}
+
+	// the queue is intact: the first packet is still readable and a later
+	// write proceeds once there is space
+	firstRead, readErr := tun.Read()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	MessagePoolReturn(firstRead)
+	thirdPacket := newTunLinkTestPacket(3)
+	defer thirdPacket.DecRef()
+	if result := writeTunLinkPacket(tun.ep, thirdPacket); result.err != nil || result.n != 1 {
+		t.Fatalf("post-drop link write = %d, %v; want 1, nil", result.n, result.err)
+	}
+	thirdRead, readErr := tun.Read()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	MessagePoolReturn(thirdRead)
+	if count := tun.OutboundDropCount(); count != 1 {
+		t.Fatalf("outbound drop count after recovery = %d, want 1", count)
+	}
+}
+
+// A non-positive bound keeps the original unbounded backpressure.
+func TestTunOutboundQueueUnboundedWaitWhenDisabled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	settings := DefaultTunSettingsWithBufferSize(1)
+	settings.OutboundQueueWaitTimeout = 0
+	tun, err := CreateTun(ctx, settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tun.Close()
+
+	firstPacket := newTunLinkTestPacket(1)
+	defer firstPacket.DecRef()
+	if result := writeTunLinkPacket(tun.ep, firstPacket); result.err != nil || result.n != 1 {
+		t.Fatalf("first link write = %d, %v; want 1, nil", result.n, result.err)
+	}
+	secondPacket := newTunLinkTestPacket(2)
+	defer secondPacket.DecRef()
+	done := make(chan tunLinkWriteResult, 1)
+	go func() {
+		done <- writeTunLinkPacket(tun.ep, secondPacket)
+	}()
+	select {
+	case result := <-done:
+		t.Fatalf("unbounded write returned without space: %d, %v", result.n, result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	firstRead, readErr := tun.Read()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	MessagePoolReturn(firstRead)
+	select {
+	case result := <-done:
+		if result.err != nil || result.n != 1 {
+			t.Fatalf("released link write = %d, %v; want 1, nil", result.n, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queue space did not release the blocked link writer")
+	}
+	secondRead, readErr := tun.Read()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	MessagePoolReturn(secondRead)
+}

--- a/tun_outbound_wait_test.go
+++ b/tun_outbound_wait_test.go
@@ -2,6 +2,8 @@ package connect
 
 import (
 	"context"
+	"encoding/binary"
+	"net"
 	"testing"
 	"time"
 )
@@ -113,4 +115,116 @@ func TestTunOutboundQueueUnboundedWaitWhenDisabled(t *testing.T) {
 		t.Fatal(readErr)
 	}
 	MessagePoolReturn(secondRead)
+}
+
+// The self-deadlock itself, end to end through the real gVisor stack: the
+// goroutine that drains the tun's outbound queue is also the one injecting
+// inbound packets (socks tun reader -> SendPacket -> receive callback ->
+// Tun.Write). When the injected packet provokes a reply — here a RST for a
+// flow nothing is listening on — netstack writes that reply back into the
+// outbound queue. With the queue full and its only consumer inside this very
+// call, an unbounded wait never returns. The bounded wait drops the reply and
+// lets the reader continue, exactly as a saturated NIC queue would.
+func TestTunInjectingReaderDoesNotDeadlockOnFullOutboundQueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	settings := DefaultTunSettingsWithBufferSize(1)
+	settings.OutboundQueueWaitTimeout = 100 * time.Millisecond
+	tun, err := CreateTun(ctx, settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tun.Close()
+
+	// fill the single outbound slot so the queue has no room for the reply
+	queueFiller := newTunLinkTestPacket(1)
+	defer queueFiller.DecRef()
+	if result := writeTunLinkPacket(tun.ep, queueFiller); result.err != nil || result.n != 1 {
+		t.Fatalf("queue-filling link write = %d, %v; want 1, nil", result.n, result.err)
+	}
+
+	// this is the injection the reader makes while holding the queue
+	syn := newTunClosedPortSynPacket(t, tun)
+	written := make(chan error, 1)
+	go func() {
+		_, writeErr := tun.Write(syn)
+		written <- writeErr
+	}()
+	select {
+	case writeErr := <-written:
+		if writeErr != nil {
+			t.Fatalf("inbound injection returned %v", writeErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the injecting reader deadlocked: netstack's reply waited for queue space that only this goroutine drains")
+	}
+
+	// the reply was dropped rather than queued, and the queue still works
+	if count := tun.OutboundDropCount(); count == 0 {
+		t.Fatal("no outbound drop was counted for the dropped reply")
+	}
+	queued, readErr := tun.Read()
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	MessagePoolReturn(queued)
+
+	// the same injection with the bound disabled is the deadlock this guards
+	// against: it must not return while the queue stays full.
+	unboundedSettings := DefaultTunSettingsWithBufferSize(1)
+	unboundedSettings.OutboundQueueWaitTimeout = 0
+	unboundedTun, err := CreateTun(ctx, unboundedSettings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unboundedTun.Close()
+	unboundedFiller := newTunLinkTestPacket(1)
+	defer unboundedFiller.DecRef()
+	if result := writeTunLinkPacket(unboundedTun.ep, unboundedFiller); result.err != nil || result.n != 1 {
+		t.Fatalf("unbounded queue-filling link write = %d, %v; want 1, nil", result.n, result.err)
+	}
+	unboundedWritten := make(chan error, 1)
+	go func() {
+		_, writeErr := unboundedTun.Write(newTunClosedPortSynPacket(t, unboundedTun))
+		unboundedWritten <- writeErr
+	}()
+	select {
+	case <-unboundedWritten:
+		t.Fatal("unbounded injection returned without queue space; this test can no longer detect the deadlock")
+	case <-time.After(500 * time.Millisecond):
+	}
+	// Close releases the blocked writer so the goroutine does not leak
+	unboundedTun.Close()
+	select {
+	case <-unboundedWritten:
+	case <-time.After(5 * time.Second):
+		t.Fatal("closing the tun did not release the blocked injection")
+	}
+}
+
+// A SYN addressed to the tun's own address on a port nothing is listening on:
+// gVisor answers it with a RST written back to the link endpoint.
+func newTunClosedPortSynPacket(t *testing.T, tun *Tun) []byte {
+	t.Helper()
+	if len(tun.localAddresses) == 0 {
+		t.Fatal("tun has no local address")
+	}
+	path := &IpPath{
+		Version:         4,
+		Protocol:        IpProtocolTcp,
+		SourceIp:        net.IPv4(198, 51, 100, 2).To4(),
+		SourcePort:      40001,
+		DestinationIp:   net.IP(tun.localAddresses[0].AsSlice()),
+		DestinationPort: 9,
+	}
+	packet, tcpHeader := ipTransportPacket(path, ipProtocolNumberTcp, TcpHeaderSizeWithoutExtensions)
+	binary.BigEndian.PutUint16(tcpHeader[0:2], uint16(path.SourcePort))
+	binary.BigEndian.PutUint16(tcpHeader[2:4], uint16(path.DestinationPort))
+	binary.BigEndian.PutUint32(tcpHeader[4:8], 1000)
+	tcpHeader[12] = byte(TcpHeaderSizeWithoutExtensions/4) << 4
+	tcpHeader[13] = tcpFlagSyn
+	binary.BigEndian.PutUint16(tcpHeader[14:16], 65535)
+	binary.BigEndian.PutUint16(tcpHeader[16:18], ipPathTransportChecksum(path, ipProtocolNumberTcp, tcpHeader))
+	return packet
 }


### PR DESCRIPTION
`tunLinkEndpoint.WritePackets` waited without bound for space in the outbound (tun read) queue. The goroutine that drains that queue can itself be inside an inbound injection, and then the whole netstack stops.

The chain, captured in goroutine dumps of every unrecovered collapse on the socks client (stock, and on its own in 2 of 8 runs with the flight-gate fix from the companion PR): the socks client's tun reader calls `SendPacket`; the multi-client synchronously hands a race-buffered response to the receive callback (`ip_remote_multi_client.go`, `deliverReceivePacket`); the callback writes it into netstack via `Tun.write` (holding the tcp inbound shard lock); netstack answers it — a RST for a closed flow (`replyWithReset`) — by writing back to the tun; that write waits in `WritePackets` for queue space that only this blocked reader would have drained. Behind it pile up netstack timers, new dials, the receive sequences behind the shard lock, and `Client.run` behind a full receive queue. Nothing is read from any transport afterwards, so nothing can ever unblock it.

## Change

- `TunSettings.OutboundQueueWaitTimeout` (default 250 ms — far above a healthy drain interval). `WritePackets` waits at most that long for space and then drops the rest of the write like a saturated NIC queue, counted in `Tun.OutboundDropCount()`.
- A non-positive timeout keeps the previous unbounded backpressure. The existing backpressure and close tests still hold.

A link endpoint that can block netstack indefinitely can deadlock any synchronous injector; gVisor's own channel endpoint drops rather than blocks for the same reason.

## Rig validation

6 runs with this change (on top of the flight-gate fix): 0 dead 15 s windows in 60, versus 5 dead windows in 80 from this deadlock without it.

## Tests

`tun_outbound_wait_test.go`: `TestTunOutboundQueueDropsAfterBoundedWait`, `TestTunOutboundQueueUnboundedWaitWhenDisabled`, and `TestTunInjectingReaderDoesNotDeadlockOnFullOutboundQueue` — the deadlock itself through the real gVisor stack (the queue's only consumer injects a SYN for a closed port; gVisor's RST is written back into the full queue). Its second half runs the same injection with `OutboundQueueWaitTimeout = 0` and requires it *not* to return, so the test cannot silently stop detecting the deadlock if the bound is removed.

## Verification (this branch, on current `main`)

```
go build ./...   exit 0
go vet ./...     exit 0
gofmt -l         clean
go test ./       ok github.com/urnetwork/connect 425.636s  (full suite, -count=1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GhKjxoZXQVBZnxb2mNzNL

