### PR TITLE
transfer: defer a timeout resend while cumulative ACKs are still advancing

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -1364,6 +1364,7 @@ type ClientSendRecoveryStatsSnapshot struct {
 	InitialMessageByteCount               uint64
 	TimeoutResendWriteCount               uint64
 	AckPendingResendPreemptCount          uint64
+	TimeoutResendDeferCount               uint64
 	CarrierChangeWriteCount               uint64
 	SelectiveGapWriteCount                uint64
 	AckTailProbeWriteCount                uint64
@@ -1452,6 +1453,7 @@ type Client struct {
 	selectiveGapWriteCount                 atomic.Uint64
 	timeoutResendWriteCount                atomic.Uint64
 	ackPendingResendPreemptCount           atomic.Uint64
+	timeoutResendDeferCount                atomic.Uint64
 	carrierChangeWriteCount                atomic.Uint64
 	ackTailProbeWriteCount                 atomic.Uint64
 	cumulativeProbeWriteCount              atomic.Uint64
@@ -1789,6 +1791,7 @@ func (self *Client) SendRecoveryStats() ClientSendRecoveryStatsSnapshot {
 		InitialMessageByteCount:             self.initialSendMessageByteCount.Load(),
 		TimeoutResendWriteCount:             self.timeoutResendWriteCount.Load(),
 		AckPendingResendPreemptCount:        self.ackPendingResendPreemptCount.Load(),
+		TimeoutResendDeferCount:             self.timeoutResendDeferCount.Load(),
 		CarrierChangeWriteCount:             self.carrierChangeWriteCount.Load(),
 		SelectiveGapWriteCount:              self.selectiveGapWriteCount.Load(),
 		AckTailProbeWriteCount:              self.ackTailProbeWriteCount.Load(),
@@ -4755,6 +4758,8 @@ type SendSequence struct {
 	idleCondition *IdleCondition
 
 	rttWindow *RttWindow
+	// lastHeadAckTime is when the cumulative (head) ACK last advanced.
+	lastHeadAckTime time.Time
 
 	contractMultiRouteWriter            MultiRouteWriter
 	contractMultiRouteWriterDestination TransferPath
@@ -5872,6 +5877,7 @@ sendSequenceLoop:
 		ackSnapshot := ackWindow.Snapshot(true)
 		ackUpdated := 0 < ackSnapshot.ackUpdateCount || 0 < len(ackSnapshot.selectiveAcks)
 		if 0 < ackSnapshot.ackUpdateCount {
+			self.lastHeadAckTime = time.Now()
 			self.receiveAck(
 				ackSnapshot.headAck.messageId,
 				false,
@@ -5992,6 +5998,10 @@ sendSequenceLoop:
 				// ordinary cadence. Any resend awaits fresh acknowledgement state.
 				recoveryKind := item.recoveryKind
 				item.recoveryKind = sendRecoveryNone
+				if recoveryKind == sendRecoveryNone && self.deferTimeoutResend(item, sendTime) {
+					self.resendQueue.Add(item)
+					continue
+				}
 				reliableOnlyResend := false
 				if recoveryKind == sendRecoveryNone && item.unreliableFlightTracked {
 					reliableOnlyResend = self.observeUnreliableResendTimeout(item, flightPolicy)
@@ -7426,6 +7436,28 @@ func (self *SendSequence) observeAckRtt(item *sendItem, tag sequenceTag) {
 	self.rttWindow.CloseSendTime(tag.sendTime)
 }
 
+// deferTimeoutResend reports whether a timed-out item carried by a reliable
+// lane should wait one more scaled RTT instead of being re-sent now. While
+// the cumulative ACK is still advancing, an item behind the head is queued,
+// not lost (a real hole is recovered from selective ACKs); re-sending it only
+// deepens the queue that delayed its ACK, which is the spurious-RTO cascade
+// observed with a direct lane live. Bounded to two deferrals per item so a
+// genuine loss is still re-sent.
+func (self *SendSequence) deferTimeoutResend(item *sendItem, now time.Time) bool {
+	if item == nil || item.unreliableFlightTracked || 2 <= item.timeoutDeferCount ||
+		self.lastHeadAckTime.IsZero() {
+		return false
+	}
+	rtt := self.rttWindow.ScaledRtt()
+	if rtt < now.Sub(self.lastHeadAckTime) {
+		return false
+	}
+	item.timeoutDeferCount += 1
+	item.resendTime = now.Add(rtt)
+	self.client.timeoutResendDeferCount.Add(1)
+	return true
+}
+
 func (self *SendSequence) unreliableFlightGates(
 	policy transferFlightPolicySnapshot,
 ) bool {
@@ -8029,6 +8061,9 @@ type sendItem struct {
 	ackTailProbeCount     int
 	recoveryKind          sendRecoveryKind
 	promotedHead          bool
+	// timeoutDeferCount bounds how many times a timed-out item waits one more
+	// RTT while cumulative ACKs are still advancing (deferTimeoutResend).
+	timeoutDeferCount int
 	// forceUnwrapped pins this item to plaintext on every (re)send, so the
 	// outer wrap is skipped even if the per-peer cipher becomes available
 	// between the initial send and a retransmit.

--- a/transfer_flight_fallback_test.go
+++ b/transfer_flight_fallback_test.go
@@ -308,3 +308,45 @@ func TestSelectiveAckGapSkipsReliableItemsNotYetLateInMixedLanes(t *testing.T) {
 		t.Fatal("single-lane gap recovery regressed")
 	}
 }
+
+// A timed-out reliable-carried item waits (at most twice) while cumulative
+// acks are still advancing; it is re-sent at once when acks have stalled or
+// when it rode the unreliable lane.
+func TestSendSequenceDefersTimeoutResendWhileAcksProgress(t *testing.T) {
+	settings := DefaultSendBufferSettings()
+	sequence := testUnreliableRecoverySequence(settings)
+	sequence.client = &Client{}
+	sequence.flightController = newSendFlightController(settings)
+	now := time.Now()
+
+	item := &sendItem{transferFrameBytes: make([]byte, 64)}
+	sequence.observeCarrierWrite(item, transferWriteDisposition{reliable: true})
+	sequence.lastHeadAckTime = now.Add(-50 * time.Millisecond)
+	if !sequence.deferTimeoutResend(item, now) || item.timeoutDeferCount != 1 || !item.resendTime.After(now) {
+		t.Fatalf("first deferral: count=%d resendTime=%s", item.timeoutDeferCount, item.resendTime)
+	}
+	if !sequence.deferTimeoutResend(item, now) || item.timeoutDeferCount != 2 {
+		t.Fatalf("second deferral: count=%d", item.timeoutDeferCount)
+	}
+	if sequence.deferTimeoutResend(item, now) {
+		t.Fatal("third deferral granted; must resend")
+	}
+	if sequence.client.SendRecoveryStats().TimeoutResendDeferCount != 2 {
+		t.Fatalf("deferral stat = %d, want 2", sequence.client.SendRecoveryStats().TimeoutResendDeferCount)
+	}
+
+	stalled := &sendItem{transferFrameBytes: make([]byte, 64)}
+	sequence.observeCarrierWrite(stalled, transferWriteDisposition{reliable: true})
+	sequence.lastHeadAckTime = now.Add(-30 * time.Second)
+	if sequence.deferTimeoutResend(stalled, now) {
+		t.Fatal("deferred a timeout while acks were stalled")
+	}
+
+	unreliable := &sendItem{transferFrameBytes: make([]byte, 64)}
+	sequence.observeCarrierWrite(unreliable, transferWriteDisposition{unreliable: true})
+	sequence.lastHeadAckTime = now
+	if sequence.deferTimeoutResend(unreliable, now) {
+		t.Fatal("deferred a timeout of an unreliable-carried item")
+	}
+	sequence.releaseUnreliableFlight(unreliable)
+}


### PR DESCRIPTION
Follow-up to #208, which fixed the pinned-provider collapse. This addresses the remaining timeout behaviour on the relay lane when a direct datagram lane is also live.

## The problem

The sequence's scaled RTO is `2 × mean RTT` with a 300 ms floor. On the relay path that estimate sits *below* the queue-inflated round trip under load, so a whole window of relay-carried items times out and is re-sent while their ACKs are still in flight. The resends add load, which adds delay, which fires more timeouts. On the provider this shows as bursts above 1,000 timeout resends per 2 s, recurring every 2-4 s for as long as the direct lane stays up, with no packet loss anywhere to justify them.

#208's `observeAckRtt` stopped ~20 ms direct-lane ACKs from dragging that estimate toward its floor, which removed one contributor. The cascade persisted.

## The change

An item whose sequence is still seeing its cumulative ACK advance is not evidence of loss — only of a round trip longer than the current estimate. Such an item now waits one more scaled RTT before its timeout resend, at most twice, after which it resends exactly as before.

Deliberately narrow:

- **Unreliable-carried items are excluded.** Loss on the datagram lane is real, and deferring its recovery would be wrong.
- **A sequence whose ACKs have stopped advancing is untouched**, so a genuinely stalled flow recovers on the original schedule. This is the case that matters for the collapse #208 fixed, and it is explicitly not slowed.
- **At most two deferrals**, so a pathological path cannot defer indefinitely.

Counted as `ClientSendRecoveryStatsSnapshot.TimeoutResendDeferCount`.

## Rig validation

16 runs on a pinned own-provider setup (Mac socks client → platform → VPS provider), interleaved against the same build without this change, with the A/B order alternating per pair so drift in link conditions cancels. Every run passed a sample-gap check for client sleep; none discarded.

The direct lane activates in only about half of runs, so the comparable unit is a sample in which it was actually carrying, pooled per arm:

|                                | with this change | without |
|--------------------------------|------------------|---------|
| p2p-live runs / samples        | 4 / 128          | 5 / 199 |
| timeout resends per live sample| **44**           | 907     |
| storm samples (>1000 per 2 s)  | **0**            | 49      |
| gap resends per live sample    | 65               | 66      |
| mean Mb/s while live           | 64               | 53      |
| dead windows                   | 0/80             | 0/80    |

Timeout resends drop 20.6×, and storms go to zero: 0 of 4 runs versus 4 of 5 (Fisher exact p=0.048). Gap resends are unchanged, which is expected — they are not what this targets.

⚠️ **The throughput difference is not claimed.** +21% while the direct lane is live is a point estimate over 4 live runs per arm (p≈0.19). An interim read at 2 runs per arm showed no difference at all. Neither sample settles it, and the change is offered on the timeout behaviour, which is unambiguous. Relay-only runs are unaffected (means 88 vs 81, within this path's hour-to-hour drift).

## What this does *not* fix

With the storms gone and gap resends already reduced by #208, a live direct lane still costs roughly a quarter of throughput (~64 Mb/s live versus ~88 relay-only). So the cascade was a symptom, not the binding constraint. The remaining suspect is structural — one ordered stream striped across a ~20 ms lane and a ~150-300 ms lane, with the datagram lane's flight pinned near its 8 KiB floor, so the fast lane carries little while still imposing reordering cost on the relay. That is a design question rather than a bug, and is left alone here.

## Tests

`TestSendSequenceDefersTimeoutResendWhileAcksProgress` covers the deferral, the two-deferral cap, the unreliable-carrier exclusion, and the stalled-sequence passthrough.

## Verification

```
go build ./...   exit 0
go vet ./...     exit 0
gofmt -l         clean
go test ./...    ok connect 425.914s · blocker · connectctl · emoji · extender · security — exit 0
```

Full suite on this branch, on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GhKjxoZXQVBZnxb2mNzNL
